### PR TITLE
docs: refresh README positioning and BIOBUZZ V0 rule references

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ ViDAR **detects and remembers**. It does **not** own field pose or drive your ro
 
 ```mermaid
 flowchart LR
-  Cam[1ΓÇô4 USB webcams] --> Hub[Control Hub]
-  Hub --> MV[VidarMultiVision]
-  MV --> WM[VidarWorldModel]
-  MV --> Op[Your OpMode / auto stack]
+  Cam["1-4 USB webcams"] --> Hub["Control Hub"]
+  Hub --> MV["VidarMultiVision"]
+  MV --> WM["VidarWorldModel"]
+  MV --> Op["OpMode or auto stack"]
   WM --> Op
-  Op -.->|optional| PED[Pedro / Road Runner / custom auto]
-  Sim[Browser sim] -.->|same tuning| MV
+  Op -.-> PED["Optional pathing library"]
+  Sim["Browser sim"] -.-> MV
 ```
 
 Integration notes and validation checklist: [docs/ROADMAP.md](docs/ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿<p align="center">
+<p align="center">
   <img src="assets/vidar-logo-transparent.svg" alt="ViDAR" width="120" />
 </p>
 
@@ -11,10 +11,10 @@
 </p>
 
 <p align="center">
-  <a href="docs/SYSTEM_DESIGN.md"><strong>System design</strong></a> ┬╖
-  <a href="docs/API.md"><strong>API contract</strong></a> ┬╖
-  <a href="#browser-simulator"><strong>Browser simulator</strong></a> ┬╖
-  <a href="#quick-start"><strong>Quick start</strong></a> ┬╖
+  <a href="docs/SYSTEM_DESIGN.md"><strong>System design</strong></a> ·
+  <a href="docs/API.md"><strong>API contract</strong></a> ·
+  <a href="#browser-simulator"><strong>Browser simulator</strong></a> ·
+  <a href="#quick-start"><strong>Quick start</strong></a> ·
   <a href="#using-vidar-in-your-code"><strong>Using ViDAR in your code</strong></a>
 </p>
 
@@ -34,7 +34,7 @@ ViDAR helps teams:
 - **See game pieces and plates reliably:** color-blob detection with geometric filtering, optional local Hough validation, and uncertainty-weighted range fusion (size, floor LUT, ground plane).
 - **Tell friend from foe at runtime:** alliance from a REV Color Sensor on your robot sign and/or gamepad override at INIT.
 - **Use AprilTags sparingly but reliably:** scout every frame; official FTC decode capped at **1 per second**; scout observations never alter absolute pose.
-- **Scale to 1ΓÇô4 cameras:** per-camera ROIs, mounts, and scheduling; fusion picks the best global element, plate, and tag each loop.
+- **Scale to 1–4 cameras:** per-camera ROIs, mounts, and scheduling; fusion picks the best global element, plate, and tag each loop.
 - **Tune before hardware:** browser simulator mirrors Java logic so students can iterate on ROIs, colors, and calibration overlays on a laptop.
 - **Integrate your way:** read observations from any OpMode; Pedro Pathing and other autos are optional consumers, not dependencies.
 
@@ -65,7 +65,7 @@ Repository: **[The-Allsparks/ViDAR](https://github.com/The-Allsparks/ViDAR)**
 | Multi-camera fusion + world model | Implemented; **not hardware-validated at 4 cameras** |
 | AprilTag scout + async decode | Implemented; tested in simulation |
 | Browser simulator + Python parity tests | Available |
-| Sustained 4├ù USB webcam on Control Hub | **Requires team validation.** See [docs/ROADMAP.md](docs/ROADMAP.md) |
+| Sustained 4× USB webcam on Control Hub | **Requires team validation.** See [docs/ROADMAP.md](docs/ROADMAP.md) |
 
 Feature-level labels and maturity notes: [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DESIGN.md).
 
@@ -102,9 +102,9 @@ Default pipeline: **`VidarContourProcessor`**, one scaled ROI pass for season **
 
 | Target | Approach |
 |--------|----------|
-| **Elements** | HSV mask ΓåÆ contour geometry ΓåÆ optional local Hough |
-| **Plates** | Color mask ΓåÆ rotated rect ΓåÆ white-digit gate ΓåÆ width-based range |
-| **AprilTags** | Scout every frame; official decode Γëñ 1 s globally |
+| **Elements** | HSV mask → contour geometry → optional local Hough |
+| **Plates** | Color mask → rotated rect → white-digit gate → width-based range |
+| **AprilTags** | Scout every frame; official decode ≤ 1 s globally |
 
 Per-camera ROIs default to **lower 65%** (elements), **middle 40%** (plates), and **upper 65%** (tags): overlapping bands, not a fixed 50/50 split.
 
@@ -119,7 +119,7 @@ Up to three slant-range estimates fused with uncertainty weighting:
 
 ### Multi-camera
 
-Set `VidarConfig.CAMERA_COUNT` (1ΓÇô4). Name webcams **`Webcam 1`** ΓÇª **`Webcam 4`**. Each index uses `VidarCameraProfile.FOUR_SIDES` (0┬░ / 90┬░ / 180┬░ / 270┬░ bearings + mount offsets). Copy a template from [`config/robots/`](config/robots/README.md) and recalibrate floor LUT on-field.
+Set `VidarConfig.CAMERA_COUNT` (1–4). Name webcams **`Webcam 1`** … **`Webcam 4`**. Each index uses `VidarCameraProfile.FOUR_SIDES` (0° / 90° / 180° / 270° bearings + mount offsets). Copy a template from [`config/robots/`](config/robots/README.md) and recalibrate floor LUT on-field.
 
 ### OpModes
 
@@ -141,9 +141,9 @@ Tune before hardware: mock scene or webcam, detection overlays, calibration-axis
 # or: python scripts/serve_sim.py
 ```
 
-Open **http://127.0.0.1:8765** ΓåÆ **Start**.
+Open **http://127.0.0.1:8765** → **Start**.
 
-Tuning file: `sim/vidar-tuning.json` Γåö `VidarConfig.java` / season JSON.
+Tuning file: `sim/vidar-tuning.json` ↔ `VidarConfig.java` / season JSON.
 
 Run offline tests:
 
@@ -169,11 +169,11 @@ python -m pytest tests/ -v
 ### 2. Install on the Control Hub
 
 1. Clone the [FTC SDK](https://github.com/FIRST-Tech-Challenge/FtcRobotController) and open it in Android Studio.
-2. Copy `teamcode/org/firstinspires/ftc/teamcode/vidar/` ΓåÆ `TeamCode/src/main/java/.../vidar/`.
+2. Copy `teamcode/org/firstinspires/ftc/teamcode/vidar/` → `TeamCode/src/main/java/.../vidar/`.
 3. Copy a robot template from [`config/robots/`](config/robots/README.md) to `TeamCode/src/main/assets/vidar/robot.json`.
-4. Configure USB webcams as **`Webcam 1`** ΓÇª **`Webcam 4`** (see `VidarConfig.CAMERA_NAMES`).
-5. Set `VidarConfig.CAMERA_COUNT` (1ΓÇô4).
-6. Run **ViDAR: Discover** ΓåÆ **ViDAR: TeleOp** ΓåÆ **ViDAR: Auto Seek**.
+4. Configure USB webcams as **`Webcam 1`** … **`Webcam 4`** (see `VidarConfig.CAMERA_NAMES`).
+5. Set `VidarConfig.CAMERA_COUNT` (1–4).
+6. Run **ViDAR: Discover** → **ViDAR: TeleOp** → **ViDAR: Auto Seek**.
 
 ### Alliance (friend / foe)
 
@@ -211,7 +211,7 @@ ViDAR **detects and remembers**. It does **not** own field pose or drive your ro
 |--------|-------------|
 | `VidarElementObservation` / `VidarPlateObservation` | TeleOp assist, intake alignment, foe avoidance |
 | `VidarWorldModel` | Short-term tracks (`nearestElement()`, ranked frames) |
-| AprilTag decode (Γëñ 1 s) | Sparse field fixes when **you** fuse them with odom / Pinpoint |
+| AprilTag decode (≤ 1 s) | Sparse field fixes when **you** fuse them with odom / Pinpoint |
 
 **Standalone:** **ViDAR: TeleOp**, **ViDAR: Auto Seek**, and custom OpModes work with no pathing dependency.
 
@@ -262,7 +262,7 @@ The competition path remains **Java + browser sim**.
 
 ## Acknowledgements
 
-ViDARΓÇÖs coordinate-frame and calibration architecture was **substantially informed** by [**Matt Vitelli**](https://github.com/MattVitelli)ΓÇÖs presentation [*How Robots Understand Space*](https://vivalosmentors.org/wp-content/uploads/2026/08/How_Robots_Understand_Space-Vitelli.pdf) ([Viva Los Mentors](https://vivalosmentors.org/details/)). That work motivated explicit frames, destination-from-source transform chains, practical intrinsic/extrinsic calibration, visualization-first validation, and offline pose refinement, adapted here for FTC vision on the Control Hub.
+ViDAR’s coordinate-frame and calibration architecture was **substantially informed** by [**Matt Vitelli**](https://github.com/MattVitelli)’s presentation [*How Robots Understand Space*](https://vivalosmentors.org/wp-content/uploads/2026/08/How_Robots_Understand_Space-Vitelli.pdf) ([Viva Los Mentors](https://vivalosmentors.org/details/)). That work motivated explicit frames, destination-from-source transform chains, practical intrinsic/extrinsic calibration, visualization-first validation, and offline pose refinement, adapted here for FTC vision on the Control Hub.
 
 Full attribution and frame conventions: [docs/COORDINATE_FRAMES.md](docs/COORDINATE_FRAMES.md).
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,149 @@
-# ViDAR
+﻿<p align="center">
+  <img src="assets/vidar-logo-transparent.svg" alt="ViDAR" width="120" />
+</p>
 
-Low-resolution, CPU-conscious vision for FTC — **game-element tracking**, **friend/foe plates**, and **sparse AprilTags** on the Control Hub.
+<h1 align="center">ViDAR</h1>
 
-## What it does
+<p align="center">
+  <strong>Robot-space situational awareness for FTC</strong><br />
+  Vision-based tracking of game elements, friend/foe plates, and AprilTags.<br />
+  Explicit coordinate frames, multi-camera fusion, and CPU-conscious pipelines on the Control Hub.
+</p>
 
-| Layer | Element / plate ROIs (configurable, overlapping) | Tag ROI (upper band) |
-|-------|-----------------------------------------------------|----------------------|
-| **Elements** | Color-blob + geometric filter + optional local Hough | — |
-| **Plates** | Color mask → rotated rect → white-digit gate → width-based range | — |
-| **Tags** | — | Scout every frame; official FTC decode ≤ 1 s |
+<p align="center">
+  <a href="docs/SYSTEM_DESIGN.md"><strong>System design</strong></a> ┬╖
+  <a href="docs/API.md"><strong>API contract</strong></a> ┬╖
+  <a href="#browser-simulator"><strong>Browser simulator</strong></a> ┬╖
+  <a href="#quick-start"><strong>Quick start</strong></a> ┬╖
+  <a href="#using-vidar-in-your-code"><strong>Using ViDAR in your code</strong></a>
+</p>
 
-Default element pipeline: **color segmentation** via `VidarContourProcessor` (unified element + plate pass), not full-frame Hough. Per-camera ROIs default to lower 65% (element), middle 40% (plate), upper 65% (tag) — not a fixed 50/50 split.
+---
 
-Supports **1–4 USB webcams** architecturally; sustained multi-camera USB stability requires **hardware validation** on your Control Hub. Scout tag observations **never alter absolute pose** — only decoded AprilTags pass localization gates.
+## What is ViDAR?
 
-**Localization** (odom + tag fusion for Pedro pathing) is a **separate system** that consumes ViDAR outputs — see [docs/ROADMAP.md](docs/ROADMAP.md).
+ViDAR turns USB webcam images into **positions in robot space**. It is not a pixel tracker: every observation carries an explicit frame, calibrated range, and (when fused) a short-term world-model track your OpMode can act on.
 
-## Quick links
+For **FIRST Tech Challenge** teams, that means game elements and alliance plates reported as robot-relative range and bearing, multi-camera handoff without guessing which camera saw what, and sparse AprilTag decode on a strict CPU budget. Vision is the sensor; **spatial understanding** is the product.
 
-| Path | Purpose |
-|------|---------|
-| [docs/API.md](docs/API.md) | Cross-language outer-layer API contract |
-| [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DESIGN.md) | Architecture and feature status |
-| [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | Tuning reference |
-| [docs/CALIBRATION.md](docs/CALIBRATION.md) | Field calibration workflow |
-| [docs/TEACHING.md](docs/TEACHING.md) | Java lessons for Control Hub |
-| [docs/ROADMAP.md](docs/ROADMAP.md) | Multi-cam wiring, validation, Pedro |
-| [sim/](sim/) | Browser simulator with live overlays |
-| `teamcode/.../vidar/` | OpModes to copy into FTC SDK |
+Use it on its own in TeleOp and custom OpModes, or wire it into your autonomous stack. **No pathing library required.** If you use [Pedro Pathing](https://pedropathing.com/), Road Runner, or a hand-written auto, ViDAR exposes observations and a world model your code can read directly.
+
+ViDAR helps teams:
+
+- **Know where things are in robot space:** calibrated range, bearing, and robot-frame positions from explicit coordinate frames and transform chains (not raw blob centroids).
+- **See game pieces and plates reliably:** color-blob detection with geometric filtering, optional local Hough validation, and uncertainty-weighted range fusion (size, floor LUT, ground plane).
+- **Tell friend from foe at runtime:** alliance from a REV Color Sensor on your robot sign and/or gamepad override at INIT.
+- **Use AprilTags sparingly but reliably:** scout every frame; official FTC decode capped at **1 per second**; scout observations never alter absolute pose.
+- **Scale to 1ΓÇô4 cameras:** per-camera ROIs, mounts, and scheduling; fusion picks the best global element, plate, and tag each loop.
+- **Tune before hardware:** browser simulator mirrors Java logic so students can iterate on ROIs, colors, and calibration overlays on a laptop.
+- **Integrate your way:** read observations from any OpMode; Pedro Pathing and other autos are optional consumers, not dependencies.
+
+**Competition path:** Java on the Control Hub. Python and Docker are for off-robot simulation, tests, and experiments only.
+
+> **Disclaimer:** ViDAR is community-developed and unofficial. It is **not** affiliated with or endorsed by FIRST, REV Robotics, or other referenced vendors. Teams must verify legality and performance against the current-season FTC manual.
+
+---
+
+## Built by The Allsparks
+
+ViDAR is created and maintained by **[The Allsparks](https://github.com/The-Allsparks)** (FTC Team **#36117**), a FIRST Tech Challenge team in Las Vegas, Nevada.
+
+We built ViDAR for our own multi-camera robot: explicit coordinate frames, honest CPU budgeting, and a sim-first workflow so students can learn robot-space awareness without blocking drive practice. We publish it for other FTC teams who want the same foundations, and welcome issues, field validation reports, and pull requests.
+
+Repository: **[The-Allsparks/ViDAR](https://github.com/The-Allsparks/ViDAR)**
+
+---
+
+## Current status
+
+**Version 0.2.0**
+
+| Area | Status |
+|------|--------|
+| Unified element + plate contour pipeline | Implemented; tested in simulation |
+| Per-camera overlapping ROIs + alliance selector | Implemented; tested in simulation |
+| Multi-camera fusion + world model | Implemented; **not hardware-validated at 4 cameras** |
+| AprilTag scout + async decode | Implemented; tested in simulation |
+| Browser simulator + Python parity tests | Available |
+| Sustained 4├ù USB webcam on Control Hub | **Requires team validation.** See [docs/ROADMAP.md](docs/ROADMAP.md) |
+
+Feature-level labels and maturity notes: [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DESIGN.md).
+
+---
+
+## Explore
+
+| Resource | Description |
+|----------|-------------|
+| [System design](docs/SYSTEM_DESIGN.md) | Architecture, pipelines, and feature status |
+| [API contract](docs/API.md) | Cross-language names, units, and telemetry fields |
+| [Configuration](docs/CONFIGURATION.md) | Season JSON, robot JSON, tuning reference |
+| [Calibration](docs/CALIBRATION.md) | Floor LUT, ROI, and field calibration workflow |
+| [Coordinate frames](docs/COORDINATE_FRAMES.md) | Frames, transforms, intrinsics, validation |
+| [Teaching guide](docs/TEACHING.md) | Java lessons for Control Hub development |
+| [Roadmap](docs/ROADMAP.md) | Multi-cam USB wiring, validation, optional pathing integration |
+| [Browser simulator](#browser-simulator) | Tune ROIs and colors before deploying to the hub |
+| [Robot templates](config/robots/README.md) | SVPRO vs C920 example `robot.json` files |
+| [Pedro Pathing](https://pedropathing.com/) | Optional: one supported autonomous stack (not required) |
+
+---
+
+## Key capabilities
+
+### Spatial model
+
+Every detection is anchored in explicit frames (`ROBOT`, `CAMERA_OPTICAL`, `IMAGE`, and field when tags decode). Mount pose, intrinsics, and transform chains convert pixels into **robot-frame range, bearing, and position**. `VidarWorldModel` motion-corrects short-term tracks so your OpMode sees a stable picture of what is around the robot.
+
+See [docs/COORDINATE_FRAMES.md](docs/COORDINATE_FRAMES.md) for conventions and calibration.
+
+### Detection
+
+Default pipeline: **`VidarContourProcessor`**, one scaled ROI pass for season **elements** and **plates** (not full-frame Hough).
+
+| Target | Approach |
+|--------|----------|
+| **Elements** | HSV mask ΓåÆ contour geometry ΓåÆ optional local Hough |
+| **Plates** | Color mask ΓåÆ rotated rect ΓåÆ white-digit gate ΓåÆ width-based range |
+| **AprilTags** | Scout every frame; official decode Γëñ 1 s globally |
+
+Per-camera ROIs default to **lower 65%** (elements), **middle 40%** (plates), and **upper 65%** (tags): overlapping bands, not a fixed 50/50 split.
+
+### Ranging and fusion
+
+Up to three slant-range estimates fused with uncertainty weighting:
+
+- **Elements:** SIZE + FLOOR LUT + GROUND_PLANE
+- **Plates:** plate width + FLOOR + ground @ z = 0
+
+**ViDAR: Discover** telemetry shows `size=` / `floor=` / `ground=` on the element detail line.
+
+### Multi-camera
+
+Set `VidarConfig.CAMERA_COUNT` (1ΓÇô4). Name webcams **`Webcam 1`** ΓÇª **`Webcam 4`**. Each index uses `VidarCameraProfile.FOUR_SIDES` (0┬░ / 90┬░ / 180┬░ / 270┬░ bearings + mount offsets). Copy a template from [`config/robots/`](config/robots/README.md) and recalibrate floor LUT on-field.
+
+### OpModes
+
+| OpMode | Purpose |
+|--------|---------|
+| **ViDAR: Discover** | Live detection telemetry and tuning feedback |
+| **ViDAR: TeleOp** | Drive while vision runs |
+| **ViDAR: Auto Seek** | Demo autonomous seek using fused observations |
+| **ViDAR ROI Calibrate** | Per-camera ROI and horizon calibration |
+
+---
 
 ## Browser simulator
 
-Tune before hardware — mock scene or webcam, overlays for elements, plates, tags, and auto-seek.
+Tune before hardware: mock scene or webcam, detection overlays, calibration-axis preview, and auto-seek. Same JSON tuning as on-robot Java.
 
 ```powershell
 .\scripts\serve_sim.ps1
 # or: python scripts/serve_sim.py
 ```
 
-Open **http://127.0.0.1:8765** → **Start**.
+Open **http://127.0.0.1:8765** ΓåÆ **Start**.
+
+Tuning file: `sim/vidar-tuning.json` Γåö `VidarConfig.java` / season JSON.
 
 Run offline tests:
 
@@ -47,24 +152,28 @@ pip install -r requirements-dev.txt
 python -m pytest tests/ -v
 ```
 
-Tuning: `sim/vidar-tuning.json` ↔ `VidarConfig.java` / `VidarTagConfig.java`.
+---
 
-## Development
+## Quick start
+
+### 1. Try the simulator (recommended)
 
 ```powershell
+git clone https://github.com/The-Allsparks/ViDAR.git
+cd ViDAR
 pip install -r requirements-dev.txt
+.\scripts\serve_sim.ps1
 python -m pytest tests/ -v
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). License: MIT — see [LICENSE](LICENSE).
+### 2. Install on the Control Hub
 
-## Java on Control Hub
-
-1. Clone [FTC SDK](https://github.com/FIRST-Tech-Challenge/FtcRobotController).
-2. Copy `teamcode/org/firstinspires/ftc/teamcode/vidar/` → `TeamCode/src/main/java/.../vidar/`.
-3. Configure USB webcams **`Webcam 1`** … **`Webcam 4`** (see `VidarConfig.CAMERA_NAMES`).
-4. Set `VidarConfig.CAMERA_COUNT` (1–4). Alliance is set at runtime — see below.
-5. Run OpModes: **Discover** → **TeleOp** → **Auto Seek**.
+1. Clone the [FTC SDK](https://github.com/FIRST-Tech-Challenge/FtcRobotController) and open it in Android Studio.
+2. Copy `teamcode/org/firstinspires/ftc/teamcode/vidar/` ΓåÆ `TeamCode/src/main/java/.../vidar/`.
+3. Copy a robot template from [`config/robots/`](config/robots/README.md) to `TeamCode/src/main/assets/vidar/robot.json`.
+4. Configure USB webcams as **`Webcam 1`** ΓÇª **`Webcam 4`** (see `VidarConfig.CAMERA_NAMES`).
+5. Set `VidarConfig.CAMERA_COUNT` (1ΓÇô4).
+6. Run **ViDAR: Discover** ΓåÆ **ViDAR: TeleOp** ΓåÆ **ViDAR: Auto Seek**.
 
 ### Alliance (friend / foe)
 
@@ -72,9 +181,11 @@ No manual constant per match. Use `VidarAllianceSelector`:
 
 | Method | When |
 |--------|------|
-| **Color sensor** on your own ROBOT SIGN (name `alliance_color` in config) | Auto at INIT |
+| **Color sensor** on your robot sign (`alliance_color` in config) | Auto at INIT |
 | **Gamepad Y** = RED, **B** = BLUE | INIT override |
 | **Back** button | Toggle during match (optional) |
+
+Mount the REV Color Sensor V3 on the **colored background** of your sign (not the white digits). Tune `ALLIANCE_COLOR_*` in `VidarConfig` if readings are ambiguous.
 
 ```java
 VidarAllianceSelector alliance = new VidarAllianceSelector(hardwareMap);
@@ -86,63 +197,79 @@ while (!isStarted() && !isStopRequested()) {
 VidarMultiVision vision = new VidarMultiVision(hardwareMap, odomSupplier, alliance::get);
 ```
 
-Mount the REV Color Sensor V3 on the **colored background** of your sign (not the white digits). Tune `ALLIANCE_COLOR_*` in `VidarConfig` if readings are ambiguous.
+### Multi-camera wiring
 
-### Multi-camera
+The Control Hub has limited USB ports. For four cameras, use a **powered USB 2.0 hub** on **USB 3.0**, with hub power from **REV +5V aux** or an approved USB battery pack. Details: [docs/ROADMAP.md#phase-5--real-world-usb-wiring](docs/ROADMAP.md#phase-5--real-world-usb-wiring).
 
-```java
-// VidarConfig.java
-public static final int CAMERA_COUNT = 4;
-public static final boolean ALLIANCE_USE_COLOR_SENSOR = true;
-```
+---
 
-Each index uses `VidarCameraProfile.FOUR_SIDES[index]` (bearing 0°/90°/180°/270° + mount offsets). Calibrate floor LUT and `focalLengthPx` **per camera**.
+## Using ViDAR in your code
 
-```java
-VidarMultiVision vision = new VidarMultiVision(hardwareMap, odomSupplier);
-VidarWorldModel world = new VidarWorldModel();
-vision.update();
-world.update(vision, System.nanoTime());
-```
+ViDAR **detects and remembers**. It does **not** own field pose or drive your robot. Your OpMode (or autonomous library) reads what ViDAR publishes:
 
-### Package layout
+| Output | Typical use |
+|--------|-------------|
+| `VidarElementObservation` / `VidarPlateObservation` | TeleOp assist, intake alignment, foe avoidance |
+| `VidarWorldModel` | Short-term tracks (`nearestElement()`, ranked frames) |
+| AprilTag decode (Γëñ 1 s) | Sparse field fixes when **you** fuse them with odom / Pinpoint |
 
-```
-vidar/
-├── VidarConfig.java / VidarRuntimeConfig.java
-├── config/                         ← season + robot JSON loaders
-├── VidarCameraProfile.java / VidarCameraMount.java
-├── VidarGeometry.java / VidarFrameRegions.java / VidarFramePipeline.java
-├── VidarContourProcessor.java      ← unified element + plate detection
-├── VidarContourDetect.java / VidarElementObservation.java
-├── VidarPlateObservation.java / VidarAllianceSelector.java
-├── VidarAdaptiveTagProcessor.java / VidarTagScoutRunner.java / VidarTagDecodeWorker.java
-├── VidarFrameMailbox.java          ← zero-copy frame handoff to worker thread
-├── VidarVision.java                ← one camera
-├── VidarMultiVision.java           ← 1–4 cameras fused
-├── VidarWorldModel.java            ← short-term spatial memory
-├── VidarDiscoverOpMode.java
-├── VidarTeleOp.java
-└── VidarAutoSeekOpMode.java
-```
+**Standalone:** **ViDAR: TeleOp**, **ViDAR: Auto Seek**, and custom OpModes work with no pathing dependency.
+
+**With autonomous pathing (optional):** fuse localization separately, then pass pose to [Pedro Pathing](https://pedropathing.com/), Road Runner, or your own state machine. ViDAR does not bundle or require any of these. The Allsparks happen to use Pedro; your team can choose differently.
 
 ```mermaid
 flowchart LR
-  Cam[1–4 USB webcams] --> Hub[Control Hub]
+  Cam[1ΓÇô4 USB webcams] --> Hub[Control Hub]
   Hub --> MV[VidarMultiVision]
   MV --> WM[VidarWorldModel]
-  MV --> Op[OpMode / Pedro / Localization]
-  Sim[Browser Sim] -.->|same tuning| MV
+  MV --> Op[Your OpMode / auto stack]
+  WM --> Op
+  Op -.->|optional| PED[Pedro / Road Runner / custom auto]
+  Sim[Browser sim] -.->|same tuning| MV
 ```
 
-## USB wiring (4 cameras)
+Integration notes and validation checklist: [docs/ROADMAP.md](docs/ROADMAP.md).
 
-Control Hub has limited USB ports — use a **powered USB 2.0 hub** (FTC docs historically recommend **Anker 4-port**) on **USB 3.0**, power hub from **REV +5V aux** or an **approved USB battery pack** (R617). Details: [docs/ROADMAP.md](docs/ROADMAP.md#phase-5--real-world-usb-wiring).
+---
+
+## Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DESIGN.md) | Architecture and feature status |
+| [docs/API.md](docs/API.md) | Cross-language outer-layer contract |
+| [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | Tuning and JSON reference |
+| [docs/CALIBRATION.md](docs/CALIBRATION.md) | Field calibration workflow |
+| [docs/CALIBRATION_CHECKLIST.md](docs/CALIBRATION_CHECKLIST.md) | Printable calibration checklist |
+| [docs/COORDINATE_FRAMES.md](docs/COORDINATE_FRAMES.md) | Frames, transforms, intrinsics |
+| [docs/TEACHING.md](docs/TEACHING.md) | Java lessons for students |
+| [docs/ROADMAP.md](docs/ROADMAP.md) | Phased plan and open work |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup and guidelines |
+
+---
 
 ## Optional: Python / Docker
 
-Off-robot experiments only (`docker compose up --build`). Competition path is Java + browser sim.
+Off-robot experiments only:
 
-## Rules
+```powershell
+docker compose up --build
+```
 
-USB webcams on the **Control Hub**, vision in the **Robot Controller app** (R715).
+The competition path remains **Java + browser sim**.
+
+---
+
+## Acknowledgements
+
+ViDARΓÇÖs coordinate-frame and calibration architecture was **substantially informed** by [**Matt Vitelli**](https://github.com/MattVitelli)ΓÇÖs presentation [*How Robots Understand Space*](https://vivalosmentors.org/wp-content/uploads/2026/08/How_Robots_Understand_Space-Vitelli.pdf) ([Viva Los Mentors](https://vivalosmentors.org/details/)). That work motivated explicit frames, destination-from-source transform chains, practical intrinsic/extrinsic calibration, visualization-first validation, and offline pose refinement, adapted here for FTC vision on the Control Hub.
+
+Full attribution and frame conventions: [docs/COORDINATE_FRAMES.md](docs/COORDINATE_FRAMES.md).
+
+**Conceptual credit only.** [Matt Vitelli](https://github.com/MattVitelli) did not author ViDAR code, endorse ViDAR, or license code to this project.
+
+---
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,8 +15,8 @@ flowchart TB
 
   subgraph vidar [ViDAR per camera]
     VP[VisionPortal]
-    CP[VidarContourProcessor — elements + plates]
-    Tags[Adaptive tags + non-localizing scout]
+    CP["VidarContourProcessor: elements and plates"]
+    Tags["Adaptive tags and non-localizing scout"]
   end
 
   subgraph fuse [Fusion layer]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # ViDAR Roadmap
 
-Phased plan for multi-camera deployment, situational awareness, Pedro pathing integration, and field validation.
+Phased plan for multi-camera deployment, robot-space situational awareness, optional pathing integration, and field validation.
 
 ## Architecture (current)
 
@@ -40,7 +40,7 @@ flowchart TB
   LOC --> PED
 ```
 
-ViDAR **detects and remembers**; it does **not** own field pose. A separate localization module should fuse Pinpoint/odom/IMU with sparse ViDAR tag fixes, then feed Pedro.
+ViDAR **detects and remembers** in robot space; it does **not** own field pose. A separate localization module should fuse Pinpoint/odom/IMU with sparse ViDAR tag fixes, then feed your autonomous stack (Pedro, Road Runner, or custom). Pathing libraries are optional consumers, not requirements.
 
 ---
 
@@ -133,13 +133,17 @@ Pedro consumes `FieldPoseProvider.get()` for path following; assisted modes read
 
 ## Phase 5 — Real-world USB wiring
 
-### Rules (2025 manual summary)
+### Rules (BIOBUZZ Competition Manual V0, Jul 2026)
+
+Re-check [Section 12](https://ftc-resources.firstinspires.org/ftc/game/manual) and Team Updates after kickoff (Sep 12, 2026). Game rules and expansion limits are not in the V0 preview.
 
 - **R602:** COTS USB battery packs ≤ 100 Wh allowed for peripherals (with constraints).
-- **R617:** Powered USB hubs may draw from:
+- **R611:** Powered USB hubs may draw from:
   - Approved COTS USB battery pack, **or**
   - REV Control Hub / Expansion Hub **+5V auxiliary port** (5 V, 2 A max per port).
-- Vision must run on Control Hub (R715); no off-board coprocessor for competition path.
+- **R707 / R708:** USB vision only; UVC webcams natively supported by the Robot Controller app (single sensor; UVC stream only). No stereoscopic cameras.
+- **R704:** During **MATCH play**, FTC Dashboard and similar third-party streaming tools are prohibited. Use Driver Station telemetry only; disconnect laptops from RC Wi-Fi.
+- Vision must run on the Control Hub via the Robot Controller app (R708); no off-board coprocessor for the competition path. Custom TeamCode (ViDAR) is allowed (R304).
 
 ### Control Hub ports
 
@@ -199,9 +203,9 @@ Structured test plan before trusting ViDAR in auto.
 
 | Metric | Target | How |
 |--------|--------|-----|
-| Element FPS per camera | ≥ 15 | Discover telemetry + FTC Dashboard |
+| Element FPS per camera | ≥ 15 | Discover telemetry (bench/practice); FTC Dashboard OK off-match only (R704) |
 | Tag decode latency | < 400 ms | Log time around decode |
-| Tag decode CPU spike | acceptable at 2 s interval | Dashboard CPU |
+| Tag decode CPU spike | acceptable at 2 s interval | Discover telemetry or Dashboard off-match |
 | Plate false positives | < 1/min on empty field | 5 min static scene |
 
 ### 1 — Single-camera calibration

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -1,5 +1,7 @@
 # ViDAR System Design
 
+ViDAR turns USB webcam detections into **calibrated positions in robot space**. Vision pipelines (color blobs, plate geometry, sparse AprilTags) feed explicit coordinate frames, range fusion, multi-camera fusion, and a short-term world model. Your OpMode reads robot-frame observations and tracks; field pose and autonomous pathing stay separate and optional.
+
 Status labels used throughout ViDAR documentation:
 
 | Label | Meaning |
@@ -14,11 +16,11 @@ Status labels used throughout ViDAR documentation:
 ## Architecture (preserved)
 
 ```
-Per-camera detection → Multi-camera fusion → Short-term world model
+Per-camera detection → Multi-camera fusion → Short-term world model (robot space)
                               ↓
                     AprilTag observations (localization separate)
                               ↓
-                    Pedro Pathing via external pose provider
+                    Your OpMode / optional auto stack (Pedro, Road Runner, custom)
 ```
 
 ## Element detection — **Implemented**, **Tested in simulation**
@@ -102,3 +104,18 @@ Browser sim (`sim/`) mirrors Java logic for ROIs, color-blob detection, weighted
 ## Competition legality
 
 Teams must verify final implementation against the current-season FTC manual. ViDAR does not claim competition readiness without team validation.
+
+Reviewed against **BIOBUZZ Competition Manual V0** (Jul 2026). Nothing in V0 appears to prohibit ViDAR's architecture (UVC webcams + custom Java on the Control Hub). Re-check after kickoff when game rules and expansion limits (R105) are published.
+
+| Topic | BIOBUZZ V0 rule | ViDAR note |
+|-------|-----------------|------------|
+| On-robot vision | R708 | UVC webcams via Robot Controller app; each camera must be natively supported (validate SVPRO or other models on your hub) |
+| USB wiring | R707, R611, R602 | Hub + cameras on USB; hub power from +5V aux or legal USB pack |
+| Custom software | R304 | ViDAR TeamCode is allowed |
+| Match networking | R704 | No FTC Dashboard or continuous streaming during MATCH play; Driver Station telemetry only |
+| Fair play | R202 | Do not put 36h11 AprilTag-like graphics on the robot |
+| Expansion / game rules | R105, Section 11 | **TBD at kickoff** (Sep 12, 2026) |
+
+Off-robot tools (browser sim, Python tests, Docker) are for development only and must not run vision during matches.
+
+Manual: [ftc-resources.firstinspires.org/ftc/game/manual](https://ftc-resources.firstinspires.org/ftc/game/manual)

--- a/docs/TEACHING.md
+++ b/docs/TEACHING.md
@@ -1,6 +1,6 @@
-# ViDAR — Java teaching path
+# ViDAR Java teaching path
 
-End-to-end Java on the **Control Hub** using the official FTC SDK vision APIs. One language, one device, competition-legal.
+End-to-end Java on the **Control Hub** using the official FTC SDK vision APIs. The goal is **robot-space awareness**: calibrated range, bearing, and tracks your OpMode can use, not raw pixels. One language, one device, competition-legal.
 
 ## Prerequisites
 

--- a/docs/validation-log.md
+++ b/docs/validation-log.md
@@ -17,7 +17,7 @@ Re-run on Control Hub hardware before competition.
 |----------|--------|-----------|-------|
 | Element FPS per camera | ≥ 15 | | `python scripts/bench_metrics.py` |
 | Tag decode latency | < 400 ms | | Manual OpMode |
-| Tag decode CPU spike | acceptable at 2 s interval | | Manual OpMode |
+| Tag decode CPU spike | acceptable at 2 s interval | | Manual OpMode (Dashboard off-match only per R704) |
 | Plate false positives | < 1/min on empty field | | Manual / sim |
 
 ## 1 — Single-camera calibration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vidar"
 version = "0.2.0"
-description = "FTC vision library — off-robot Python companion for ViDAR Java"
+description = "Off-robot Python companion for ViDAR: robot-space spatial awareness for FTC (simulation and tests)"
 readme = "README.md"
 requires-python = ">=3.11"
 

--- a/sim/index.html
+++ b/sim/index.html
@@ -10,7 +10,7 @@
   <header class="header">
     <div>
       <h1>ViDAR Simulator</h1>
-      <p class="subtitle">Browser vision preview with detection overlays — matches on-robot Java tuning</p>
+      <p class="subtitle">Robot-space preview with detection and calibration overlays. Matches on-robot Java tuning.</p>
     </div>
     <div class="header-stats">
       <div class="stat"><span class="stat-label">FPS</span><span id="fps" class="stat-value">—</span></div>

--- a/src/vidar/__init__.py
+++ b/src/vidar/__init__.py
@@ -1,4 +1,4 @@
-"""ViDAR - high-speed low-resolution vision for FTC element gathering and avoidance."""
+"""ViDAR: robot-space spatial awareness for FTC (off-robot Python companion for Java on the Control Hub)."""
 
 from vidar.geometry import (
     build_size_estimate,


### PR DESCRIPTION
## Summary
- Rewrite README around **robot-space situational awareness** (not low-res vision), with The Allsparks (#36117) branding, Matt Vitelli attribution, and optional (not required) pathing integration
- Expand SYSTEM_DESIGN competition legality section from BIOBUZZ Competition Manual V0 review
- Fix stale rule references in ROADMAP (R715/R617 -> R708/R611) and note R704 match-time Dashboard limits
- Align package metadata (pyproject.toml, Python docstring) and sim subtitle with the new positioning

## Test plan
- [ ] README renders correctly on GitHub (logo, mermaid, tables)
- [ ] Rule citations link to [BIOBUZZ V0 manual](https://ftc-resources.firstinspires.org/ftc/game/manual)
- [ ] No broken internal doc links