### PR TITLE
Spatial facade, motion tracks, and sim parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ViDAR
+﻿# ViDAR
 
 Low-resolution, CPU-conscious vision for FTC — **game-element tracking**, **friend/foe plates**, and **sparse AprilTags** on the Control Hub.
 
@@ -24,6 +24,7 @@ Supports **1–4 USB webcams** architecturally; sustained multi-camera USB stabi
 | [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DESIGN.md) | Architecture and feature status |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | Tuning reference |
 | [docs/CALIBRATION.md](docs/CALIBRATION.md) | Field calibration workflow |
+| [docs/CALIBRATION_CHECKLIST.md](docs/CALIBRATION_CHECKLIST.md) | One-page setup before first match |
 | [docs/COORDINATE_FRAMES.md](docs/COORDINATE_FRAMES.md) | Frames, transforms, intrinsics, validation |
 | [docs/TEACHING.md](docs/TEACHING.md) | Java lessons for Control Hub |
 | [docs/ROADMAP.md](docs/ROADMAP.md) | Multi-cam wiring, validation, Pedro |
@@ -65,7 +66,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). License: MIT — see [LICENSE](LICENSE).
 2. Copy `teamcode/org/firstinspires/ftc/teamcode/vidar/` → `TeamCode/src/main/java/.../vidar/`.
 3. Configure USB webcams **`Webcam 1`** … **`Webcam 4`** (see `VidarConfig.CAMERA_NAMES`).
 4. Set `VidarConfig.CAMERA_COUNT` (1–4). Alliance is set at runtime — see below.
-5. Run OpModes: **Discover** → **TeleOp** → **Auto Seek**.
+5. Run OpModes: **Discover** → **Spatial** → **Spatial Map**.
+
+ViDAR is a **spatial system only** — pose plus three groups (`elements()`, `allies()`, `foes()`). It never commands motors.
 
 ### Alliance (friend / foe)
 
@@ -122,9 +125,10 @@ vidar/
 ├── VidarVision.java                ← one camera
 ├── VidarMultiVision.java           ← 1–4 cameras fused
 ├── VidarWorldModel.java            ← short-term spatial memory
+├── VidarSpatial.java               ← pose + targets / anti-targets facade
 ├── VidarDiscoverOpMode.java
-├── VidarTeleOp.java
-└── VidarAutoSeekOpMode.java
+├── VidarTeleOp.java                ← ViDAR: Spatial
+└── VidarAutoSeekOpMode.java        ← ViDAR: Spatial Map
 ```
 
 ```mermaid

--- a/config/robots/README.md
+++ b/config/robots/README.md
@@ -31,6 +31,8 @@ Wrong `focalLengthPx` skews SIZE (e.g. C920 defaults on SVPRO ≈ **38% error**)
 
 ## Required after copying a template
 
+See **[docs/CALIBRATION_CHECKLIST.md](../../docs/CALIBRATION_CHECKLIST.md)** for the one-page setup list. Summary:
+
 1. Match `webcamName` to Driver Station camera names (`Webcam 1` … `Webcam 4`).
 2. Set `cameraCount` to the number of physical cameras.
 3. **Re-run floor LUT** at 12 / 24 / 36 / 48 in (or your check distances) — templates mark `"floorLutStatus": "example-placeholder-recalibrate-on-robot"`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -300,6 +300,8 @@ close(): void
 
 **Setup:** copy `config/robots/*.json` → `assets/vidar/robot.json` — see [CALIBRATION_CHECKLIST.md](CALIBRATION_CHECKLIST.md).
 
+Motion-corrected tracks require an odom supplier at `create()`. Field pose for tracks extrapolates from odom between tag fixes; optional `setFieldPoseSupplier()` for Pedro-primary pose.
+
 ### `VidarSpatialPoint`
 
 | Field | Type | Notes |

--- a/docs/API.md
+++ b/docs/API.md
@@ -162,6 +162,7 @@ Immutable fused game-piece detection.
 
 | Field | Type | Notes |
 |-------|------|-------|
+| `elementId` | string | season element id from `season.json` |
 | `cameraName` | string | |
 | `captureTimeNanos` | int64 | VisionPortal `frameCaptureNanos` at mailbox publish |
 | `cx`, `cy` | float | image center, full-frame px |
@@ -178,7 +179,7 @@ Immutable fused game-piece detection.
 | `robotX`, `robotY` | float | robot-frame floor point |
 | `houghVotes` | int | 0 for color-blob path |
 
-Python extension: `elementId` string (map key in Java is external via `getGameElement(id)`).
+Python `ElementObservation` should include matching `elementId` when sim parity is updated.
 
 ### `PlateObservation` / `VidarPlateObservation`
 
@@ -254,6 +255,77 @@ processFrame(frame, captureTimeNanos) // Java VisionProcessor entry
 | `getGameElement(elementId)` | best observation for that season element id |
 | `getGameElements()` | `Map<string, ElementObservation>` |
 | `getBestPlate()` | best `PlateObservation` or null |
+
+---
+
+## Spatial facade (Java — recommended for OpModes)
+
+Pedro-style entry point: one object, one `update()` per loop. Wraps `VidarMultiVision` + `VidarWorldModel`. Does **not** require Pedro Pathing.
+
+### `VidarSpatial`
+
+```
+create(hardwareMap): VidarSpatial
+create(hardwareMap, odomSupplier, allianceSupplier): VidarSpatial
+create(hardwareMap, robot, season, odomSupplier, allianceSupplier): VidarSpatial
+
+update(): void
+updateCorrected(): VidarCorrectedFrame    // when odom supplier configured
+
+bestElement(): VidarSpatialPoint | null       // LIVE
+nearestElement(): VidarSpatialPoint | null    // REMEMBERED when motion tracking active
+elements(): List<VidarSpatialPoint>           // ranked live + remembered tracks
+allies(): List<VidarSpatialPoint>
+foes(): List<VidarSpatialPoint>
+bestFoe() / nearestFoe() / bestAlly(): VidarSpatialPoint | null
+intakeBlocked(): bool
+offensiveLaneAnalysis(): VidarOffensiveLaneAnalysis
+recommendOffensiveLane(): VidarOffensiveLane   // LEFT | CENTER | RIGHT
+trackCount(): int                               // 0 when motion tracking inactive
+fieldPose(): Pose2D | null
+robotPose(): Pose2D | null
+isOdomConfigured(): bool
+isMotionTrackingEnabled(): bool
+isMotionTrackingActive(): bool                // enabled && odom supplier
+setMotionTrackingEnabled(enabled): void
+distanceUnit(): DistanceUnit
+cameraCount(): int
+
+setFieldPosePrior(pose): void
+setFieldPoseSupplier(supplier): void          // e.g. Pedro follower pose for world tracks
+vision(): VidarMultiVision                    // advanced escape hatch
+worldModel(): VidarWorldModel
+close(): void
+```
+
+**Setup:** copy `config/robots/*.json` → `assets/vidar/robot.json` — see [CALIBRATION_CHECKLIST.md](CALIBRATION_CHECKLIST.md).
+
+### `VidarSpatialPoint`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | `ELEMENT`, `FOE`, `ALLY` | |
+| `source` | `LIVE`, `REMEMBERED` | |
+| `trackId` | int | stable id when motion tracking active; `-1` for live-only |
+| `elementId` | string | season element id; empty for plates |
+| `occurrenceRank` | int | per-type rank 0 = closest/easiest; `-1` if N/A |
+| `velFieldXInPerSec`, `velFieldYInPerSec` | float | field-frame velocity on remembered tracks |
+| `robotX`, `robotY` | float | robot frame floor point (+X forward, +Y left) |
+| `range` | float | fused slant range |
+| `confidence` | float | 0–1 |
+| `bearingDeg()` | float | 0° = ahead, + = left |
+| `distance()` | float | `hypot(robotX, robotY)` |
+
+**Team integration:** after `spatial.update()`, read pose and iterate `elements()`, `allies()`, `foes()`. Use `recommendOffensiveLane()` for Phase 3 offensive lane choice (lowest foe density in forward cone). Motion-corrected tracks require an odom supplier and `isMotionTrackingActive()`. ViDAR never outputs motor commands.
+
+### `VidarOffensiveLaneAnalysis`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `leftCount` / `centerCount` / `rightCount` | int | Foes in each third of the forward cone |
+| `recommended` | `LEFT`, `CENTER`, `RIGHT` | Lane with fewest foes; tie → center, then left |
+| `maxRangeIn` | double | From `VidarConfig.OFFENSIVE_LANE_MAX_RANGE_IN` |
+| `coneHalfDeg` | double | From `VidarConfig.OFFENSIVE_LANE_CONE_HALF_DEG` |
 
 ---
 

--- a/docs/CALIBRATION_CHECKLIST.md
+++ b/docs/CALIBRATION_CHECKLIST.md
@@ -55,7 +55,7 @@ ViDAR does **not** require Pedro. If you use path following:
 
 ## 7 — Motion tracking (requires odom)
 
-Run **ViDAR: Spatial Map** with Pinpoint / Pedro / team odom wired at `create()`.
+Run **ViDAR: Spatial Map** with Pinpoint / Pedro / team odom wired at `create()`. World tracks extrapolate field pose from odom between tag fixes automatically; for Pedro-primary localization you can still call `spatial.setFieldPoseSupplier(follower::getPose)`.
 
 - [ ] Telemetry shows `Motion tracks: true`
 - [ ] Discover element line shows season `elementId` (e.g. `artifact_purple · …`)

--- a/docs/CALIBRATION_CHECKLIST.md
+++ b/docs/CALIBRATION_CHECKLIST.md
@@ -1,0 +1,70 @@
+# ViDAR calibration checklist
+
+One-page setup before relying on `robotX` / `robotY` or assisted driving. Full detail: [CALIBRATION.md](CALIBRATION.md) and [config/robots/README.md](../config/robots/README.md).
+
+## 0 — Copy config
+
+| Source (repo) | Destination (Android project) |
+|---------------|-------------------------------|
+| `config/robots/<your-template>.json` | `TeamCode/src/main/assets/vidar/robot.json` |
+| `config/seasons/<year>-<game>.json` | `TeamCode/src/main/assets/vidar/season.json` |
+
+Pick the template that matches **camera count** and **hardware** (SVPRO vs C920). See the selection table in `config/robots/README.md`.
+
+## 1 — Hardware names
+
+- [ ] `webcamName` matches Driver Station camera names (`Webcam 1` … `Webcam 4`)
+- [ ] `cameraCount` equals physical USB cameras plugged in
+- [ ] `activeCameraIndex` points at your primary forward camera (0-based)
+
+## 2 — Intrinsics (one-time per camera model)
+
+- [ ] `focalLengthPx` matches your camera at **640×480** (SVPRO ≈ 246, C920-class ≈ 340)
+- [ ] `horizontalFovDeg` / `verticalFovDeg` match product spec (sanity check only)
+
+## 3 — Mount pose
+
+- [ ] `mount.x`, `mount.y`, `mount.z` measured from robot center (inches)
+- [ ] `bearingDeg` matches physical aim (0 = forward)
+- [ ] `pitchDeg` set — run **ViDAR: ROI Calibrate** + sim **Calibration axes** overlay to verify
+
+## 4 — Floor LUT (required on-robot)
+
+Templates ship with `"floorLutStatus": "example-placeholder-recalibrate-on-robot"`.
+
+- [ ] Run **ViDAR: Discover** on the Control Hub
+- [ ] Place a game element on the floor at **12 / 24 / 36 / 48 in** (or your check distances) centered in the active camera
+- [ ] Read `size=`, `floor=`, `ground=` on the element detail line — note pixel row (`cy`) and true distance
+- [ ] Update `floorLut` rows in `robot.json` for each camera (repeat per camera if mounts differ)
+- [ ] Re-deploy and confirm fusion confidence rises (three sources agree)
+
+## 5 — Validate ranging
+
+- [ ] `robotX` / `robotY` move in the expected direction when you slide the target left/right/forward
+- [ ] Fused range within ~15% of tape measure at 24–48 in
+- [ ] `elements()` / `foes()` bearing matches physical left/right/forward motion
+
+## 6 — Optional: field pose (Pedro / localization)
+
+ViDAR does **not** require Pedro. If you use path following:
+
+- [ ] Supply odom via `VidarSpatial.create(hardwareMap, odom::getPose, alliance::get)`
+- [ ] `spatial.setFieldPosePrior(startPose)` at auto init
+- [ ] For Pedro-primary pose: `spatial.setFieldPoseSupplier(follower::getPose)` so world tracks stay in field frame
+- [ ] Read `spatial.elements()` / `allies()` / `foes()` in team drivetrain code — ViDAR does not command motors
+
+## 7 — Motion tracking (requires odom)
+
+Run **ViDAR: Spatial Map** with Pinpoint / Pedro / team odom wired at `create()`.
+
+- [ ] Telemetry shows `Motion tracks: true`
+- [ ] Discover element line shows season `elementId` (e.g. `artifact_purple · …`)
+- [ ] `elements()` shows `elementId#0`, `#1`, … per type ranked by distance
+- [ ] Same `trackId` survives 0.5 s occlusion while robot moves slowly
+- [ ] Static ball: field velocity on track telemetry ≈ 0 in/s after ~5 frames
+- [ ] Moving foe: non-zero field velocity when opponent crosses FOV
+- [ ] `spatial.setMotionTrackingEnabled(false)` → `Motion tracks: false`, live-only lists
+
+## Done?
+
+When steps 1–5 pass on hardware, mark your team config calibrated and remove or update `floorLutStatus` in `robot.json`. Complete step 7 before competition auto that relies on remembered targets.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -71,10 +71,21 @@ Python: `from vidar.units import effective_distance_unit, format_distance, to_me
 
 ### Loading in an OpMode
 
+**Recommended** — Pedro-style spatial facade:
+
+```java
+VidarAllianceSelector alliance = new VidarAllianceSelector(hardwareMap);
+VidarSpatial spatial = VidarSpatial.create(hardwareMap, () -> odomPose, alliance::get);
+// each loop:
+spatial.update();
+VidarSpatialPoint ball = spatial.bestElement();  // robotX, robotY in inches
+```
+
+See [CALIBRATION_CHECKLIST.md](CALIBRATION_CHECKLIST.md) before first match. Advanced / direct access:
+
 ```java
 VidarSeasonConfig season = VidarTeamConfig.loadSeason(hardwareMap);
 VidarRobotConfig robot = VidarTeamConfig.loadRobot(hardwareMap);
-VidarAllianceSelector alliance = new VidarAllianceSelector(hardwareMap, robot);
 VidarMultiVision vision = new VidarMultiVision(
         hardwareMap, robot, season, () -> odomPose, alliance::get);
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -77,7 +77,9 @@ ViDAR **detects and remembers**; it does **not** own field pose. A separate loca
 | Camera scheduler (disable processors before stream stop) | **Done** |
 | Full checkerboard intrinsic calibration OpMode | **Closed — not planned** |
 | Runtime auto-switch element detector under CPU load | **Closed — not planned** (metrics only) |
-| Profile-aware tag scout ROI in `VidarTagScoutRunner` | **Open — low priority** |
+| Profile-aware tag scout ROI in `VidarTagScoutRunner` | **Done** |
+| Browser sim: `elementId`, motion tracks, offensive lane | **Done** — see [sim/README-SIM.md](../sim/README-SIM.md) |
+| Offensive lane helper on `VidarSpatial` | **Done** (`VidarOffensiveLaneAnalysis`) |
 | Four-camera USB stress validation | **Open — requires hardware** |
 
 ---
@@ -101,11 +103,12 @@ Pipeline: **HSV mask → contour → `minAreaRect` → white-digit ratio → wid
 
 | Behavior | Uses |
 |----------|------|
-| Auto element collection | `nearestElement()`, fused range, remembered bearing |
-| Defensive nudge | `intakeBlocked()`, foe tracks |
-| Offensive lane choice | foe density in forward cone (extend in your team code) |
+| Auto element collection | `elements()`, ranked live + `VidarSpatialTrack` memory (odom required) |
+| Defensive avoidance | `foes()`, `intakeBlocked()` |
+| Ally awareness | `allies()` |
+| Motion tracking | Predict → gate → associate (`VidarTrackAssociator`); field velocity on tracks |
 
-**Next:** expose `getTracks(Kind)` to Pedro `PathCommand` callbacks or a thin `VidarAssistedDrive` helper.
+**Next:** consume `spatial.elements()` / `allies()` / `foes()` in Pedro callbacks — team maps bearing/distance to motion.
 
 ---
 
@@ -229,7 +232,7 @@ Structured test plan before trusting ViDAR in auto.
 ### 4 — Integration
 
 - [ ] `VidarWorldModel` foe memory survives 1 s occlusion
-- [ ] Auto Seek stops at `PICKUP_STOP`
+- [ ] **ViDAR: Spatial Map** — `trackId` stable through 0.5 s occlusion; `elementId#0` nearest per type
 - [ ] Tag fix + odom backdating vs known field dimension
 
 ### 5 — Pedro auto routines

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -87,6 +87,22 @@ Component estimates exposed as `source0`, `source1`, and `sourceCount` (up to 3)
 
 `VidarWorldModel` motion-corrects tracks using odom delta (translation + rotation) or field-pose reprojection when available.
 
+## Spatial facade — **Implemented**, **Tested in simulation**
+
+`VidarSpatial` is the Pedro-style entry point: one `update()` per loop, no motor output.
+
+| Output | Role |
+|--------|------|
+| `fieldPose()` / `robotPose()` | Pose estimates (tag fusion + optional odom supplier) |
+| `elements()` | Season game elements (ranked live + remembered when motion tracking active) |
+| `allies()` | Friendly alliance plates |
+| `foes()` | Opponent plates |
+| `intakeBlocked()` | Spatial hint — foe in intake cone |
+
+Motion-corrected tracks run only when `isMotionTrackingActive()` (odom supplier + `WORLD_MOTION_TRACKING_ENABLED`). Without odom, queries return live detections only.
+
+**Track associator:** each cycle predicts field position (`pos + velocity × dt`), reprojects to robot frame, gates detections within `WORLD_TRACK_GATE_RADIUS_IN`, updates velocity with EMA, coasts on miss. Elements classify as `STATIC` after stable low velocity; foes/allies as `MOVING` when speed exceeds threshold.
+
 ## Multi-camera — **Implemented**, not **Hardware validated**
 
 Architecturally supports 1–4 cameras. Four simultaneous cameras require USB hub validation on the actual Control Hub — configuration success does not guarantee USB stability.

--- a/docs/TEACHING.md
+++ b/docs/TEACHING.md
@@ -10,7 +10,6 @@ End-to-end Java on the **Control Hub** using the official FTC SDK vision APIs. O
    - USB cameras named **`Webcam 1`** … **`Webcam 4`** (match `VidarConfig.CAMERA_NAMES`)
    - Set `VidarConfig.CAMERA_COUNT` to the number installed
    - Optional: REV Color Sensor named **`alliance_color`** on your own ROBOT SIGN
-   - For TeleOp lesson: drive motors **`left`** and **`right`**
 
 ## Install ViDAR into your robot project
 
@@ -50,21 +49,23 @@ Build and deploy to the Control Hub like any other OpMode.
 
 **Concepts:** VisionProcessor, color contour + `minEnclosingCircle`, known-size ranging, floor-row LUT, multi-camera profiles.
 
-### Lesson 2 — `VidarTeleOp` (drive + crude avoidance)
+### Lesson 2 — `VidarTeleOp` / **ViDAR: Spatial** (pose + nearest targets)
 
-**Goal:** Gamepad tank drive + turn away when a detected element is near center of view.
+**Goal:** Read field pose, nearest target, nearest anti-target, and `intakeBlocked()` on telemetry. **No motors** — your drivetrain consumes spatial data.
 
-1. Wire a simple two-motor drive; names must match `VidarConfig`.
-2. Run **ViDAR: TeleOp**.
-3. Hold a colored object in front of the camera — robot should nudge aside.
+1. Run **ViDAR: Spatial**.
+2. Hold a game element in view — nearest target line updates with robot-frame `(fwd, left)`.
+3. Block the intake cone with a foe plate — `intakeBlocked` goes true.
 
-**Concepts:** Reading `getBestElement()` / alliance plates, simple proportional avoidance, combining manual + automatic inputs.
+**Concepts:** `VidarSpatial.update()`, `fieldPose()`, `elements()`, `allies()`, `foes()`, `isMotionTrackingActive()`.
 
-### Lesson 3 — `VidarAutoSeekOpMode` (autonomous seek)
+### Lesson 3 — `VidarAutoSeekOpMode` / **ViDAR: Spatial Map** (full spatial lists)
 
-**Goal:** Turn toward element, drive with power scaled by fused range, stop at pickup distance.
+**Goal:** See every remembered element and foe track after `update()`. **No motors** — map lists to Pedro or your follower in team code.
 
-Try the same logic in the **browser sim** first — sidebar shows range, size/floor cross-check, and SEARCH / TURN / DRIVE / AT PICKUP states.
+Calibrate first: [CALIBRATION_CHECKLIST.md](CALIBRATION_CHECKLIST.md).
+
+Try the same logic in the **browser sim** first — sidebar shows range and spatial overlays.
 
 ### Lesson 4 — Browser simulator (no robot)
 
@@ -83,7 +84,7 @@ Ideas in order of difficulty:
 
 | Project | What to change |
 |---------|----------------|
-| Drive toward a specific element | Use `getBestElement()` center X → `turn` toward target |
+| Drive toward a specific element | Iterate `spatial.elements()` → bearing + distance → your drivetrain |
 | Autonomous grab line | New `@Autonomous` OpMode, no gamepad |
 | Custom HSV color | Add or edit an entry in `config/seasons/*.json` |
 | Second camera | Second `VisionPortal` + second `VidarVision` instance (ports 5555-style not needed — USB on hub) |
@@ -92,13 +93,15 @@ Ideas in order of difficulty:
 
 ```
 VidarConfig.java / config/     ← tune camera, season elements, floor LUT
-VidarCameraProfile.java      ← per-side bearing + horizon + calibration
-VidarContourProcessor        ← unified element + plate detection + range overlay
-VidarGeometry.java           ← size/floor fusion math (VidarRangeResult)
-VidarVision.java             ← portal wiring (contour + tag processors)
-VidarDiscoverOpMode          ← read-only test OpMode
-VidarAutoSeekOpMode.java     ← range-based autonomous approach
-VidarTeleOp.java             ← OpMode that uses vision to affect motors
+VidarSpatial.java              ← recommended OpMode entry (vision + world model + target lists)
+VidarCameraProfile.java        ← per-side bearing + horizon + calibration
+VidarContourProcessor          ← unified element + plate detection + range overlay
+VidarGeometry.java             ← size/floor fusion math (VidarRangeResult)
+VidarMultiVision.java          ← advanced multi-camera fusion
+VidarVision.java               ← portal wiring (contour + tag processors)
+VidarDiscoverOpMode            ← read-only test OpMode
+VidarTeleOp.java               ← ViDAR: Spatial (no motors)
+VidarAutoSeekOpMode.java       ← ViDAR: Spatial Map (no motors)
 ```
 
 ## SDK samples to compare

--- a/docs/validation-log.md
+++ b/docs/validation-log.md
@@ -51,7 +51,10 @@ Re-run on Control Hub hardware before competition.
 | Test row | Pass/Fail | Notes |
 |----------|-----------|-------|
 | `VidarWorldModel` foe memory survives 1 s occlusion | | |
-| Auto Seek stops at `PICKUP_STOP` | | |
+| Spatial Map lists match live element position | | |
+| Same `trackId` survives 0.5 s element occlusion with odom | | |
+| `elementId#0` / `#1` per type ranked by distance | | |
+| Static element field velocity ≈ 0 after settle | | |
 | Tag fix + odom backdating vs known field dimension | | |
 
 ## 5 — Pedro auto routines

--- a/sim/README-SIM.md
+++ b/sim/README-SIM.md
@@ -1,0 +1,41 @@
+# ViDAR browser simulator
+
+Local vision preview that mirrors on-robot Java tuning (`sim/vidar-tuning.json`).
+
+## Run
+
+From the repo root:
+
+```powershell
+.\scripts\serve_sim.ps1
+```
+
+Or:
+
+```bash
+python scripts/serve_sim.py
+```
+
+Open **http://localhost:8765**.
+
+## Parity with robot code
+
+| Feature | Sim module | Java |
+|---------|------------|------|
+| Contour element + plate detection | `contour-processor.js` | `VidarContourProcessor` |
+| Range fusion (size + floor LUT) | `geometry.js` | `VidarGeometry` |
+| Temporal filter (3/5) | `temporal-filter.js` | `VidarTemporalFilter` |
+| Tag scout + gated decode | `tag-pipeline.js` | `VidarTagScoutRunner` / `VidarAdaptiveTagProcessor` |
+| Profile tag ROI (upper fraction) | `tag-pipeline.js` `tagRoi()` | `VidarFrameRegions.tagRoi()` |
+| `elementId` on detections | `contour-processor.js` | `VidarElementObservation.elementId` |
+| Motion tracks (predict / gate / associate) | `spatial-tracks.js` | `VidarTrackAssociator` |
+| Offensive lane (foe density) | `offensive-lane.js` | `VidarOffensiveLaneAnalysis` |
+
+## Spatial preview sidebar
+
+- **Motion tracks** — uses confirmed detections plus tag odom (`tagState.odom`) when present. Remembered tracks render as dashed circles with `T{id}` labels.
+- **Offensive lane** — counts foe tracks in left / center / right thirds of the forward cone (same defaults as `VidarConfig`).
+
+## Captures
+
+**Capture still** saves frame, process view, mask, and JSON metadata under `captures/` when the server is running.

--- a/sim/index.html
+++ b/sim/index.html
@@ -173,8 +173,20 @@
         </dl>
       </section>
       <section class="card">
+        <h2>Spatial preview</h2>
+        <p class="muted-line">Motion tracks use tag odom when available; dashed circles = remembered tracks.</p>
+        <label class="control checkbox detect-toggle">
+          <input type="checkbox" id="motion-tracks" checked>
+          <span>Motion tracks (predict / gate / associate)</span>
+        </label>
+        <dl class="metrics">
+          <div><dt>Tracks</dt><dd id="spatial-tracks">—</dd></div>
+          <div><dt>Offensive lane</dt><dd id="offensive-lane">—</dd></div>
+        </dl>
+      </section>
+      <section class="card">
         <h2>AprilTag (adaptive)</h2>
-        <p class="muted-line">Scout top half every frame; official decode on cropped ROI only (≤1 / 2s). Purple box = decode band (~25% of frame).</p>
+        <p class="muted-line">Scout profile tag ROI (upper 65% default); official decode on cropped ROI only (≤1 / 2s). Purple box = decode band.</p>
         <button id="tag-sample-btn" type="button">Request tag sample</button>
         <dl class="metrics">
           <div><dt>Tag scout</dt><dd id="tag-scout">—</dd></div>

--- a/sim/js/app.js
+++ b/sim/js/app.js
@@ -16,6 +16,12 @@ import { drawMockScene } from "./mock-scene.js";
 import { renderFrame, describeLogic } from "./renderer.js";
 import { saveCapture, canvasToDataUrl, downloadDataUrl } from "./capture.js";
 import { drawImageNative, setElementAspectRatio, toGrayscaleImageData } from "./canvas-util.js";
+import {
+  createSpatialTrackState,
+  updateSpatialTracks,
+  assignOccurrenceRanks,
+} from "./spatial-tracks.js";
+import { analyzeOffensiveLane } from "./offensive-lane.js";
 
 const display = /** @type {HTMLCanvasElement} */ (document.getElementById("display"));
 const capture = /** @type {HTMLCanvasElement} */ (document.getElementById("capture"));
@@ -36,6 +42,9 @@ const elementRobotXYEl = document.getElementById("element-robot-xy");
 const tagScoutEl = document.getElementById("tag-scout");
 const tagFixEl = document.getElementById("tag-fix");
 const tagPoseNowEl = document.getElementById("tag-pose-now");
+const spatialTracksEl = document.getElementById("spatial-tracks");
+const offensiveLaneEl = document.getElementById("offensive-lane");
+const motionTracksCheck = /** @type {HTMLInputElement | null} */ (document.getElementById("motion-tracks"));
 const tagSampleBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById("tag-sample-btn"));
 const captureStatusEl = document.getElementById("capture-status");
 const processSizeLabel = document.getElementById("process-size-label");
@@ -84,6 +93,9 @@ let tagState = createTagState();
 
 /** @type {import('./temporal-filter.js').TemporalFilterState} */
 let temporalState = createTemporalFilterState();
+
+/** @type {ReturnType<typeof createSpatialTrackState>} */
+let spatialTrackState = createSpatialTrackState();
 
 /** @type {{ detections: import('./temporal-filter.js').StableDetection[], rawDetections: import('./detection.js').Detection[], roi: {x:number,y:number,w:number,h:number}, elementMask: Uint8Array | null, maskPixels: number, tuning: import('./config.js').VidarTuning, detectOpts: ReturnType<typeof readDetectOptions>, activeDetectors: string } | null} */
 let lastFrame = null;
@@ -239,6 +251,11 @@ cropOffsetInput.addEventListener("input", () => {
 temporalFilterCheck.addEventListener("change", () => {
   temporalState = createTemporalFilterState();
 });
+if (motionTracksCheck) {
+  motionTracksCheck.addEventListener("change", () => {
+    spatialTrackState = createSpatialTrackState();
+  });
+}
 
 startBtn.addEventListener("click", () => start());
 stopBtn.addEventListener("click", () => stop());
@@ -249,6 +266,7 @@ async function start() {
   if (!tuning || running) return;
   running = true;
   temporalState = createTemporalFilterState();
+  spatialTrackState = createSpatialTrackState();
   startBtn.disabled = true;
   stopBtn.disabled = false;
   captureBtn.disabled = false;
@@ -295,6 +313,7 @@ async function start() {
 function stop() {
   running = false;
   temporalState = createTemporalFilterState();
+  spatialTrackState = createSpatialTrackState();
   cancelAnimationFrame(rafId);
   startBtn.disabled = false;
   stopBtn.disabled = true;
@@ -362,6 +381,33 @@ function loop() {
   const detections = filtered.stable;
   const logicDetections = confirmedDetections(detections);
 
+  const motionEnabled = motionTracksCheck?.checked ?? false;
+  spatialTrackState = updateSpatialTracks(
+    spatialTrackState,
+    logicDetections,
+    performance.now(),
+    tagState.odom,
+    { enabled: motionEnabled },
+  );
+  const occurrenceRanks = assignOccurrenceRanks(
+    spatialTrackState.tracks.filter((t) => t.kind === "ELEMENT"),
+  );
+  for (const det of detections) {
+    const match = spatialTrackState.tracks.find(
+      (t) => t.kind === "ELEMENT" && t.elementId === (det.elementId ?? det.name)
+        && Math.hypot(t.cx - det.cx, t.cy - det.cy) < 8,
+    );
+    if (match) {
+      det.trackId = match.trackId;
+      det.trackSource = match.source;
+      const rank = occurrenceRanks.get(match.trackId);
+      if (rank != null) det.occurrenceRank = rank;
+    }
+  }
+
+  const foeTracks = spatialTrackState.tracks.filter((t) => t.kind === "FOE");
+  const lane = analyzeOffensiveLane(foeTracks);
+
   const best = bestByCategory(logicDetections, tuning.processHeight, tuning.geometry);
   const logic = describeLogic(best, tuning);
 
@@ -375,6 +421,8 @@ function loop() {
     tuning,
     detectOpts,
     activeDetectors,
+    spatialTracks: spatialTrackState.tracks,
+    offensiveLane: lane,
   };
 
   const maskCanvas = elementMask
@@ -392,9 +440,14 @@ function loop() {
     processCanvas,
     maskCanvas,
     tagRegion: tagState.lastRegion,
+    spatialTracks: motionEnabled ? spatialTrackState.tracks : [],
   });
 
-  updateSidebar(detections, rawDetections, logic, maskPixels, tuning, activeDetectors);
+  updateSidebar(detections, rawDetections, logic, maskPixels, tuning, activeDetectors, {
+    spatialTracks: spatialTrackState.tracks,
+    offensiveLane: lane,
+    motionEnabled,
+  });
   syncDetectorUiLabels();
   updateFps();
 }
@@ -458,8 +511,8 @@ async function captureStill() {
   }
 }
 
-/** @param {import('./temporal-filter.js').StableDetection[]} detections @param {import('./detection.js').Detection[]} rawDetections @param {ReturnType<typeof describeLogic>} logic @param {number} maskPixels @param {import('./config.js').VidarTuning} tuning @param {string} [activeDetectors] */
-function updateSidebar(detections, rawDetections, logic, maskPixels, tuning, activeDetectors) {
+/** @param {import('./temporal-filter.js').StableDetection[]} detections @param {import('./detection.js').Detection[]} rawDetections @param {ReturnType<typeof describeLogic>} logic @param {number} maskPixels @param {import('./config.js').VidarTuning} tuning @param {string} [activeDetectors] @param {{ spatialTracks?: import('./spatial-tracks.js').SpatialTrack[], offensiveLane?: ReturnType<typeof analyzeOffensiveLane>, motionEnabled?: boolean }} [spatial] */
+function updateSidebar(detections, rawDetections, logic, maskPixels, tuning, activeDetectors, spatial) {
   const temporalOn = temporalFilterCheck.checked;
   if (detections.length === 0) {
     const hint = activeDetectors?.includes("element")
@@ -479,7 +532,10 @@ function updateSidebar(detections, rawDetections, logic, maskPixels, tuning, act
           d.range != null
             ? ` · ${d.range.toFixed(0)}in (size ${d.dSize?.toFixed(0) ?? "—"}/floor ${d.dFloor?.toFixed(0) ?? "—"}) conf ${((d.confidence ?? 0) * 100).toFixed(0)}%`
             : "";
-        return `<li><span class="tag" style="color:${d.color}">${d.label}</span> (${d.cx.toFixed(0)}, ${d.cy.toFixed(0)}) · ${Math.round(d.area)} px${geom}${status ? ` · <em>${status}</em>` : ""}${d.circularity != null ? ` · circ ${d.circularity.toFixed(2)}` : ""}${d.interior != null ? ` · fill ${(d.interior * 100).toFixed(0)}%` : ""}</li>`;
+        const idPart = d.elementId ? ` · ${d.elementId}` : "";
+        const rankPart = d.occurrenceRank != null && d.occurrenceRank >= 0 ? `#${d.occurrenceRank}` : "";
+        const trackPart = d.trackId != null && d.trackId >= 0 ? ` · T${d.trackId}` : "";
+        return `<li><span class="tag" style="color:${d.color}">${d.label}</span>${idPart}${rankPart}${trackPart} (${d.cx.toFixed(0)}, ${d.cy.toFixed(0)}) · ${Math.round(d.area)} px${geom}${status ? ` · <em>${status}</em>` : ""}${d.circularity != null ? ` · circ ${d.circularity.toFixed(2)}` : ""}${d.interior != null ? ` · fill ${(d.interior * 100).toFixed(0)}%` : ""}</li>`;
       })
       .join("");
     if (temporalOn && rawDetections.length > detections.length) {
@@ -536,6 +592,25 @@ function updateSidebar(detections, rawDetections, logic, maskPixels, tuning, act
     const now = backdateFieldPose(tag, tagState.odom);
     tagPoseNowEl.textContent = now
       ? `(${now.x.toFixed(1)}, ${now.y.toFixed(1)}) ${now.h.toFixed(0)}°`
+      : "—";
+  }
+  if (spatialTracksEl) {
+    const tracks = spatial?.spatialTracks ?? [];
+    if (!spatial?.motionEnabled) {
+      spatialTracksEl.textContent = "off — enable motion tracks";
+    } else if (!tracks.length) {
+      spatialTracksEl.textContent = "—";
+    } else {
+      spatialTracksEl.textContent = tracks
+        .slice(0, 4)
+        .map((t) => `T${t.trackId}${t.elementId ? ` ${t.elementId}` : ""} ${t.source} ${t.range.toFixed(0)}in`)
+        .join(" · ");
+    }
+  }
+  if (offensiveLaneEl) {
+    const lane = spatial?.offensiveLane;
+    offensiveLaneEl.textContent = lane
+      ? `${lane.recommended} (L${lane.left} C${lane.center} R${lane.right})`
       : "—";
   }
 }

--- a/sim/js/contour-processor.js
+++ b/sim/js/contour-processor.js
@@ -94,6 +94,7 @@ function blobsToContourDetections(blobs, target, tuning, data, width, height) {
     out.push({
       category,
       name: target.name,
+      elementId: target.name,
       label: target.label,
       color: target.color,
       shape: target.shape ?? "plate",

--- a/sim/js/detection.js
+++ b/sim/js/detection.js
@@ -4,7 +4,7 @@ import { roiRect } from "./config.js";
 import { detectContourTarget } from "./contour-processor.js";
 
 /**
- * @typedef {{ category: string, name: string, label: string, color: string, shape: string, cx: number, cy: number, area: number, x: number, y: number, w: number, h: number, circularity?: number, radius?: number, aspectRatio?: number, interior?: number, detector?: string, range?: number | null, dSize?: number | null, dFloor?: number | null, confidence?: number, robotX?: number | null, robotY?: number | null, cameraName?: string, bearingDeg?: number }} Detection
+ * @typedef {{ category: string, name: string, elementId?: string, label: string, color: string, shape: string, cx: number, cy: number, area: number, x: number, y: number, w: number, h: number, circularity?: number, radius?: number, aspectRatio?: number, interior?: number, detector?: string, range?: number | null, dSize?: number | null, dFloor?: number | null, confidence?: number, robotX?: number | null, robotY?: number | null, cameraName?: string, bearingDeg?: number, trackId?: number, occurrenceRank?: number, trackSource?: string }} Detection
  */
 
 /**

--- a/sim/js/geometry.js
+++ b/sim/js/geometry.js
@@ -103,6 +103,7 @@ export function applyElementGeometry(det, geometry, cameraIndex) {
 
   return {
     ...det,
+    elementId: det.elementId ?? det.name,
     dSize,
     dFloor,
     range: fused.distance,
@@ -116,14 +117,45 @@ export function applyElementGeometry(det, geometry, cameraIndex) {
   };
 }
 
+/** @param {import('./detection.js').Detection} det @param {import('./config.js').GeometryConfig} geometry @param {number} [cameraIndex] */
+export function applyPlateGeometry(det, geometry, cameraIndex) {
+  if (det.category !== "robot") return det;
+
+  const idx = cameraIndex ?? geometry.activeCameraIndex ?? 0;
+  const profile = geometry.cameras?.[idx] ?? geometry.cameras?.[0];
+  if (!profile) return det;
+
+  const plateWidthIn = 12;
+  const dSize = distanceFromWidth(plateWidthIn, profile.focalLengthPx, det.w);
+  const dFloor = distanceFromFloor(det.cy, profile);
+  const fused = fuseRangeWeighted(dSize, dFloor, { maxRangeMismatchRatio: geometry.maxRangeMismatchRatio });
+  const { x: robotX, y: robotY } = robotXYInches(fused.distance, profile.bearingDeg);
+
+  return {
+    ...det,
+    dSize,
+    dFloor,
+    range: fused.distance,
+    confidence: fused.confidence,
+    robotX,
+    robotY,
+    cameraName: profile.name,
+    bearingDeg: profile.bearingDeg,
+  };
+}
+
 /** @param {import('./detection.js').Detection[]} detections @param {import('./config.js').GeometryConfig | undefined} geometry */
 export function enrichElementGeometry(detections, geometry) {
   if (!geometry) return detections;
-  return detections.map((d) =>
-    d.category === "element" && (d.shape === "circle" || d.radius)
-      ? applyElementGeometry(d, geometry)
-      : d,
-  );
+  return detections.map((d) => {
+    if (d.category === "element" && (d.shape === "circle" || d.radius)) {
+      return applyElementGeometry(d, geometry);
+    }
+    if (d.category === "robot") {
+      return applyPlateGeometry(d, geometry);
+    }
+    return d;
+  });
 }
 
 /** @param {import('./detection.js').Detection | null | undefined} element @param {import('./config.js').GeometryConfig | undefined} geometry */

--- a/sim/js/offensive-lane.js
+++ b/sim/js/offensive-lane.js
@@ -1,0 +1,33 @@
+/** @typedef {'LEFT'|'CENTER'|'RIGHT'} OffensiveLane */
+
+/**
+ * @param {import('./spatial-tracks.js').SpatialTrack[]} foeTracks
+ * @param {{ maxRangeIn?: number, coneHalfDeg?: number }} [opts]
+ */
+export function analyzeOffensiveLane(foeTracks, opts = {}) {
+  const maxRangeIn = opts.maxRangeIn ?? 48;
+  const coneHalfDeg = opts.coneHalfDeg ?? 35;
+  const third = coneHalfDeg / 3;
+
+  let left = 0;
+  let center = 0;
+  let right = 0;
+
+  for (const foe of foeTracks) {
+    if (foe.range > maxRangeIn) continue;
+    const bearing = (Math.atan2(foe.robotY, foe.robotX) * 180) / Math.PI;
+    if (Math.abs(bearing) > coneHalfDeg) continue;
+    if (bearing < -third) left += 1;
+    else if (bearing > third) right += 1;
+    else center += 1;
+  }
+
+  const min = Math.min(left, center, right);
+  /** @type {OffensiveLane} */
+  let recommended = "CENTER";
+  if (center === min) recommended = "CENTER";
+  else if (left === min) recommended = "LEFT";
+  else recommended = "RIGHT";
+
+  return { left, center, right, recommended, maxRangeIn, coneHalfDeg };
+}

--- a/sim/js/renderer.js
+++ b/sim/js/renderer.js
@@ -213,13 +213,37 @@ export function renderFrame(ctx, sourceCanvas, detections, roiProcess, tuning, o
         temporal === "coasting" ? " hold" : "";
       const rangeTag = det.range != null ? ` ${det.range.toFixed(0)}in` : "";
       const confTag = det.confidence != null ? ` ${(det.confidence * 100).toFixed(0)}%` : "";
+      const idTag = det.elementId ? ` id=${det.elementId}` : "";
+      const rankTag = det.occurrenceRank != null && det.occurrenceRank >= 0
+        ? `#${det.occurrenceRank}`
+        : "";
+      const trackTag = det.trackId != null && det.trackId >= 0 ? ` T${det.trackId}` : "";
       ctx.fillText(
-        `${det.label}${tag} (${Math.round(det.area)}px${extra})${rangeTag}${confTag}`,
+        `${det.label}${idTag}${rankTag}${trackTag}${tag} (${Math.round(det.area)}px${extra})${rangeTag}${confTag}`,
         bx + 4,
         by - 6,
       );
       ctx.restore();
     }
+  }
+
+  if (opts.spatialTracks?.length && (opts.overlay === "all" || opts.overlay === "boxes")) {
+    drawSpatialTracks(
+      ctx,
+      opts.spatialTracks,
+      detectionView,
+      oxProc,
+      oyProc,
+      sxProc,
+      syProc,
+      oxCap,
+      oyCap,
+      sxCap,
+      syCap,
+      crop,
+      procW,
+      procH,
+    );
   }
 
   if (!detectionView && opts.showProcessPip && opts.processCanvas) {
@@ -405,6 +429,55 @@ export function describeLogic(best, tuning) {
     elementConfidence: null,
     robotXY: null,
   };
+}
+
+/**
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {import('./spatial-tracks.js').SpatialTrack[]} tracks
+ */
+function drawSpatialTracks(
+  ctx,
+  tracks,
+  detectionView,
+  oxProc,
+  oyProc,
+  sxProc,
+  syProc,
+  oxCap,
+  oyCap,
+  sxCap,
+  syCap,
+  crop,
+  procW,
+  procH,
+) {
+  for (const track of tracks) {
+    if (track.source !== "REMEMBERED") continue;
+
+    let cx;
+    let cy;
+    if (detectionView) {
+      cx = oxProc + track.cx * sxProc;
+      cy = oyProc + track.cy * syProc;
+    } else {
+      const c = processToCapture(track.cx, track.cy, crop, procW, procH);
+      cx = oxCap + c.x * sxCap;
+      cy = oyCap + c.y * syCap;
+    }
+
+    ctx.save();
+    ctx.strokeStyle = track.kind === "FOE" ? "#ff6b6b" : "#c8ff80";
+    ctx.setLineDash([5, 4]);
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(cx, cy, 14, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.fillStyle = ctx.strokeStyle;
+    ctx.font = "600 11px Segoe UI, sans-serif";
+    const id = track.elementId ? ` ${track.elementId}` : "";
+    ctx.fillText(`T${track.trackId}${id}`, cx + 10, cy - 8);
+    ctx.restore();
+  }
 }
 
 /** @param {import('./detection.js').Detection | null | undefined} element */

--- a/sim/js/spatial-tracks.js
+++ b/sim/js/spatial-tracks.js
@@ -1,0 +1,216 @@
+/**
+ * Lightweight motion-track preview — mirrors Java predict/gate/associate at robot-frame level.
+ */
+
+/** @typedef {'ELEMENT'|'FOE'} TrackKind */
+/** @typedef {'LIVE'|'REMEMBERED'} TrackSource */
+
+/**
+ * @typedef {Object} SpatialTrack
+ * @property {number} trackId
+ * @property {TrackKind} kind
+ * @property {string} elementId
+ * @property {number} robotX
+ * @property {number} robotY
+ * @property {number} cx
+ * @property {number} cy
+ * @property {number} range
+ * @property {number} confidence
+ * @property {TrackSource} source
+ * @property {number} missCount
+ * @property {number} lastUpdateMs
+ */
+
+const GATE_RADIUS_IN = 12;
+const GATE_RADIUS_FOE_IN = 18;
+const MAX_MISS = 8;
+const MIN_CONF = 0.35;
+
+/** @returns {{ tracks: SpatialTrack[], nextTrackId: number, lastOdom: { x: number, y: number, h: number } | null }} */
+export function createSpatialTrackState() {
+  return { tracks: [], nextTrackId: 1, lastOdom: null };
+}
+
+/**
+ * @param {ReturnType<typeof createSpatialTrackState>} state
+ * @param {import('./detection.js').Detection[]} detections
+ * @param {number} nowMs
+ * @param {{ x: number, y: number, h: number } | null | undefined} odom
+ * @param {{ enabled?: boolean }} [opts]
+ */
+export function updateSpatialTracks(state, detections, nowMs, odom, opts = {}) {
+  if (!opts.enabled) {
+    state.tracks = [];
+    return state;
+  }
+
+  const dets = detectionsToTracks(detections);
+  const fieldDelta = fieldDeltaFromOdom(state.lastOdom, odom);
+  state.lastOdom = odom ? { x: odom.x, y: odom.y, h: odom.h } : state.lastOdom;
+
+  /** @type {SpatialTrack[]} */
+  const predicted = state.tracks.map((t) => predictTrack(t, fieldDelta, nowMs));
+
+  if (dets.length === 0) {
+    state.tracks = predicted
+      .map((t) => coastTrack(t, nowMs))
+      .filter((t) => t.missCount <= MAX_MISS);
+    return state;
+  }
+
+  /** @type {{ ti: number, di: number, dist: number }[]} */
+  const candidates = [];
+  for (let ti = 0; ti < predicted.length; ti++) {
+    const track = predicted[ti];
+    for (let di = 0; di < dets.length; di++) {
+      const det = dets[di];
+      if (track.kind !== det.kind) continue;
+      if (track.elementId && det.elementId && track.elementId !== det.elementId) continue;
+      const dist = Math.hypot(track.robotX - det.robotX, track.robotY - det.robotY);
+      const gate = track.kind === "FOE" ? GATE_RADIUS_FOE_IN : GATE_RADIUS_IN;
+      if (dist <= gate) candidates.push({ ti, di, dist });
+    }
+  }
+  candidates.sort((a, b) => a.dist - b.dist);
+
+  const trackUsed = new Array(predicted.length).fill(false);
+  const detUsed = new Array(dets.length).fill(false);
+  /** @type {SpatialTrack[]} */
+  const updated = [];
+
+  for (const match of candidates) {
+    if (trackUsed[match.ti] || detUsed[match.di]) continue;
+    updated.push(mergeTrack(predicted[match.ti], dets[match.di], nowMs));
+    trackUsed[match.ti] = true;
+    detUsed[match.di] = true;
+  }
+
+  for (let ti = 0; ti < predicted.length; ti++) {
+    if (!trackUsed[ti]) updated.push(coastTrack(predicted[ti], nowMs));
+  }
+
+  for (let di = 0; di < dets.length; di++) {
+    if (detUsed[di]) continue;
+    const det = dets[di];
+    if (det.confidence < MIN_CONF) continue;
+    updated.push({
+      ...det,
+      trackId: state.nextTrackId++,
+      source: "LIVE",
+      missCount: 0,
+      lastUpdateMs: nowMs,
+    });
+  }
+
+  state.tracks = updated.filter((t) => t.missCount <= MAX_MISS);
+  return state;
+}
+
+/** @param {import('./detection.js').Detection[]} detections */
+function detectionsToTracks(detections) {
+  /** @type {Omit<SpatialTrack, 'trackId'|'source'|'missCount'|'lastUpdateMs'>[]} */
+  const out = [];
+  for (const d of detections) {
+    if (d.robotX == null || d.robotY == null || d.range == null) continue;
+    const conf = d.confidence ?? 1;
+    if (conf < MIN_CONF) continue;
+    if (d.category === "element") {
+      out.push({
+        kind: "ELEMENT",
+        elementId: d.elementId ?? d.name ?? "",
+        robotX: d.robotX,
+        robotY: d.robotY,
+        cx: d.cx,
+        cy: d.cy,
+        range: d.range,
+        confidence: conf,
+      });
+    } else if (d.category === "robot") {
+      out.push({
+        kind: "FOE",
+        elementId: "",
+        robotX: d.robotX,
+        robotY: d.robotY,
+        cx: d.cx,
+        cy: d.cy,
+        range: d.range,
+        confidence: conf,
+      });
+    }
+  }
+  return out;
+}
+
+/** @param {{ x: number, y: number, h: number } | null} prev @param {{ x: number, y: number, h: number } | null | undefined} next */
+function fieldDeltaFromOdom(prev, next) {
+  if (!prev || !next) return { dx: 0, dy: 0, dh: 0 };
+  return { dx: next.x - prev.x, dy: next.y - prev.y, dh: next.h - prev.h };
+}
+
+/** @param {SpatialTrack} track @param {{ dx: number, dy: number, dh: number }} delta @param {number} nowMs */
+function predictTrack(track, delta, nowMs) {
+  if (!delta.dx && !delta.dy && !delta.dh) return { ...track };
+  const rad = (-delta.dh * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const tx = track.robotX - delta.dx;
+  const ty = track.robotY - delta.dy;
+  return {
+    ...track,
+    robotX: tx * cos - ty * sin,
+    robotY: tx * sin + ty * cos,
+    source: "REMEMBERED",
+    lastUpdateMs: track.lastUpdateMs ?? nowMs,
+  };
+}
+
+/** @param {SpatialTrack} track @param {number} nowMs */
+function coastTrack(track, nowMs) {
+  return {
+    ...track,
+    source: "REMEMBERED",
+    missCount: (track.missCount ?? 0) + 1,
+    lastUpdateMs: track.lastUpdateMs ?? nowMs,
+  };
+}
+
+/**
+ * @param {SpatialTrack} track
+ * @param {Omit<SpatialTrack, 'trackId'|'source'|'missCount'|'lastUpdateMs'>} det
+ * @param {number} nowMs
+ */
+function mergeTrack(track, det, nowMs) {
+  const alpha = 0.7;
+  return {
+    ...track,
+    robotX: alpha * det.robotX + (1 - alpha) * track.robotX,
+    robotY: alpha * det.robotY + (1 - alpha) * track.robotY,
+    cx: det.cx,
+    cy: det.cy,
+    range: det.range,
+    confidence: det.confidence,
+    elementId: det.elementId || track.elementId,
+    source: "LIVE",
+    missCount: 0,
+    lastUpdateMs: nowMs,
+  };
+}
+
+/** @param {SpatialTrack[]} tracks */
+export function assignOccurrenceRanks(tracks) {
+  /** @type {Map<string, SpatialTrack[]>} */
+  const byId = new Map();
+  for (const t of tracks) {
+    if (t.kind !== "ELEMENT" || !t.elementId) continue;
+    const list = byId.get(t.elementId) ?? [];
+    list.push(t);
+    byId.set(t.elementId, list);
+  }
+  /** @type {Map<number, number>} */
+  const ranks = new Map();
+  for (const list of byId.values()) {
+    list.sort((a, b) => a.range - b.range);
+    list.forEach((t, i) => ranks.set(t.trackId, i));
+  }
+  return ranks;
+}

--- a/sim/js/tag-pipeline.js
+++ b/sim/js/tag-pipeline.js
@@ -16,20 +16,26 @@ export function bandForCx(cx, frameCols, cfg) {
   return "MIDDLE";
 }
 
-/** @param {number} frameCols @param {number} frameRows @param {HorizontalBand} band */
-export function tagDecodeCrop(frameCols, frameRows, band) {
-  const topH = Math.max(1, Math.floor(frameRows / 2));
+/** @param {number} frameCols @param {number} frameRows @param {import('./config.js').TagConfig} [cfg] */
+export function tagRoi(frameCols, frameRows, cfg) {
+  const upperFraction = cfg?.tagUpperFraction ?? 0.65;
+  const h = Math.max(1, Math.round(frameRows * upperFraction));
+  return { x: 0, y: 0, w: frameCols, h };
+}
+
+/** @param {number} frameCols @param {number} frameRows @param {HorizontalBand} band @param {import('./config.js').TagConfig} [cfg] */
+export function tagDecodeCrop(frameCols, frameRows, band, cfg) {
+  const tag = tagRoi(frameCols, frameRows, cfg);
   const cropW = Math.max(1, Math.floor(frameCols / 2));
   let x = 0;
   if (band === "RIGHT") x = frameCols - cropW;
   else if (band === "MIDDLE") x = Math.floor((frameCols - cropW) / 2);
-  return { x, y: 0, w: cropW, h: topH };
+  return { x, y: tag.y, w: cropW, h: tag.h };
 }
 
-/** @param {number} cx @param {number} cy @param {number} frameCols @param {number} frameRows @param {HorizontalBand} band */
-export function isInTagDecodeRegion(cx, cy, frameCols, frameRows, band) {
-  if (cy >= frameRows / 2) return false;
-  const r = tagDecodeCrop(frameCols, frameRows, band);
+/** @param {number} cx @param {number} cy @param {number} frameCols @param {number} frameRows @param {HorizontalBand} band @param {import('./config.js').TagConfig} [cfg] */
+export function isInTagDecodeRegion(cx, cy, frameCols, frameRows, band, cfg) {
+  const r = tagDecodeCrop(frameCols, frameRows, band, cfg);
   return cx >= r.x && cx < r.x + r.w && cy >= r.y && cy < r.y + r.h;
 }
 
@@ -39,9 +45,9 @@ export function isInTagDecodeRegion(cx, cy, frameCols, frameRows, band) {
  */
 export function runTagScout(fullFrame, cfg) {
   const { width, height, data } = fullFrame;
-  const topH = Math.floor(height / 2);
+  const tag = tagRoi(width, height, cfg);
   const scoutW = cfg.scoutWidth ?? 320;
-  const scoutH = Math.max(8, Math.round(topH * scoutW / width));
+  const scoutH = Math.max(8, Math.round(tag.h * scoutW / width));
 
   let best = null;
   let bestScore = -1;
@@ -49,7 +55,7 @@ export function runTagScout(fullFrame, cfg) {
   for (let sy = 2; sy < scoutH - 2; sy += 2) {
     for (let sx = 2; sx < scoutW - 2; sx += 2) {
       const fx = Math.floor(sx * width / scoutW);
-      const fy = Math.floor(sy * topH / scoutH);
+      const fy = Math.floor(tag.y + sy * tag.h / scoutH);
       const i = (fy * width + fx) * 4;
       const r = data[i];
       const g = data[i + 1];
@@ -213,7 +219,7 @@ export function updateTagPipeline(state, processFrame, cfg, nowMs, gate) {
   const dec = chooseDecimation(
     scout.widthPx, cfg.scoutWidth ?? 320, processFrame.width, cfg,
   );
-  const region = tagDecodeCrop(processFrame.width, processFrame.height, scout.band);
+  const region = tagDecodeCrop(processFrame.width, processFrame.height, scout.band, cfg);
   state.lastRegion = region;
   state.lastDecodeMs = nowMs;
 

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarAdaptiveTagProcessor.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarAdaptiveTagProcessor.java
@@ -102,7 +102,7 @@ public class VidarAdaptiveTagProcessor implements VisionProcessor {
             metrics.recordFrameAge((System.nanoTime() - captureTimeNanos) / 1_000_000.0);
         }
 
-        lastScout = tagScout.run(frame);
+        lastScout = tagScout.run(frame, profile);
         if (lastScout != null) {
             latestScoutObservation = VidarTagScoutObservation.fromScoutResult(
                     lastScout, profile, frame.cols(), captureTimeNanos, cameraName);

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarAutoSeekOpMode.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarAutoSeekOpMode.java
@@ -1,36 +1,36 @@
 package org.firstinspires.ftc.teamcode.vidar;
 
-import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
-import com.qualcomm.robotcore.hardware.DcMotor;
-import com.qualcomm.robotcore.hardware.DcMotorSimple;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+
+import java.util.List;
 
 /**
- * Lesson 3 — seek nearest remembered element; stop for foes blocking intake.
+ * Lesson 3 — full elements / allies / foes map (no motor output).
+ *
+ * <p>Wire odom at {@link VidarSpatial#create} to enable motion-corrected tracks.
  *
  * <p>INIT: color sensor on own sign auto-sets alliance; hold Y/B to override.
  */
-@Autonomous(name = "ViDAR: Auto Seek", group = "ViDAR")
+@TeleOp(name = "ViDAR: Spatial Map", group = "ViDAR")
 public class VidarAutoSeekOpMode extends LinearOpMode {
 
-    private DcMotor leftDrive;
-    private DcMotor rightDrive;
-    private VidarMultiVision vision;
-    private VidarWorldModel world;
+    private static final int TELEMETRY_CAP = 4;
+
+    private VidarSpatial spatial;
     private VidarAllianceSelector alliance;
 
     @Override
     public void runOpMode() {
-        leftDrive = hardwareMap.get(DcMotor.class, VidarConfig.LEFT_DRIVE);
-        rightDrive = hardwareMap.get(DcMotor.class, VidarConfig.RIGHT_DRIVE);
-        leftDrive.setDirection(DcMotorSimple.Direction.FORWARD);
-        rightDrive.setDirection(DcMotorSimple.Direction.REVERSE);
-
         alliance = new VidarAllianceSelector(hardwareMap);
-        vision = new VidarMultiVision(hardwareMap, null, alliance::get);
-        world = new VidarWorldModel();
+        spatial = VidarSpatial.create(hardwareMap, null, alliance::get);
 
-        telemetry.addLine("ViDAR Auto Seek — alliance from sensor or Y/B");
+        telemetry.addLine("ViDAR Spatial Map — three groups (no motors)");
+        telemetry.addLine("Calibrate robot.json — docs/CALIBRATION_CHECKLIST.md");
         telemetry.update();
 
         while (!isStarted() && !isStopRequested()) {
@@ -41,69 +41,45 @@ public class VidarAutoSeekOpMode extends LinearOpMode {
 
         waitForStart();
 
-        double frameWidth = VidarConfig.portalCameraResolution().getWidth();
-        VidarAlliance ours = alliance.get();
-
         while (opModeIsActive()) {
-            long now = System.nanoTime();
-            vision.update();
-            world.update(vision, now);
-            ours = alliance.get();
+            alliance.pollRuntime(gamepad1);
+            spatial.update();
 
-            VidarElementObservation element = vision.getBestElement();
-            VidarWorldModel.Track remembered = world.nearestElement();
-
-            double turn = 0;
-            double drive = 0;
-
-            if (world.intakeBlocked()) {
-                drive = 0;
-                turn = VidarConfig.AVOID_TURN_POWER;
-                telemetry.addData("State", "BLOCKED by remembered foe");
-            } else if (element != null
-                    && element.confidence >= VidarConfig.MIN_ELEMENT_CONFIDENCE
-                    && !Double.isNaN(element.range)) {
-                double error = VidarBlobUtil.errorFromCenter(element, frameWidth);
-                turn = clamp(error / (frameWidth / 2.0) * VidarConfig.SEEK_TURN_GAIN, -1, 1);
-
-                if (element.range <= VidarConfig.PICKUP_STOP) {
-                    drive = 0;
-                    telemetry.addData("State", "AT PICKUP RANGE");
-                } else if (Math.abs(error) < VidarConfig.SEEK_ALIGNED_PIXELS) {
-                    drive = VidarBlobUtil.rangeDrivePower(element);
-                    telemetry.addData("State", "DRIVING (range-scaled)");
-                } else {
-                    telemetry.addData("State", "TURNING toward element");
-                }
-            } else if (remembered != null) {
-                turn = clamp(remembered.bearingDeg() / 45.0 * VidarConfig.SEEK_TURN_GAIN, -1, 1);
-                telemetry.addData("State", "TURNING toward remembered element");
-            } else if (element != null) {
-                double error = VidarBlobUtil.errorFromCenter(element, frameWidth);
-                turn = clamp(error / (frameWidth / 2.0) * VidarConfig.SEEK_TURN_GAIN, -1, 1);
-                telemetry.addData("State", "TURNING (low confidence)");
-            } else {
-                telemetry.addData("State", "SEARCHING (slow spin)");
-                turn = VidarConfig.SEARCH_TURN_POWER;
-            }
-
-            leftDrive.setPower(drive + turn);
-            rightDrive.setPower(drive - turn);
+            List<VidarSpatialPoint> elements = spatial.elements();
+            List<VidarSpatialPoint> allies = spatial.allies();
+            List<VidarSpatialPoint> foes = spatial.foes();
+            Pose2D field = spatial.fieldPose();
 
             telemetry.addData("Alliance", alliance.formatStatus());
-            telemetry.addData("Element", VidarBlobUtil.formatElement(element));
-            telemetry.addData("Remembered", VidarBlobUtil.formatWorldTrack(remembered));
-            telemetry.addData("Foe", VidarBlobUtil.formatPlate(vision.getBestFoe(), ours));
-            telemetry.addData("Drive/Turn", "%.2f / %.2f", drive, turn);
+            telemetry.addData("Motion tracks", spatial.isMotionTrackingActive());
+            telemetry.addData("Field pose", field == null ? "—"
+                    : String.format("(%.1f, %.1f) %.0f°",
+                    field.getX(DistanceUnit.INCH),
+                    field.getY(DistanceUnit.INCH),
+                    field.getHeading(AngleUnit.DEGREES)));
+            telemetry.addData("Elements", VidarBlobUtil.formatSpatialPointList(elements, TELEMETRY_CAP));
+            telemetry.addData("Allies", VidarBlobUtil.formatSpatialPointList(allies, TELEMETRY_CAP));
+            telemetry.addData("Foes", VidarBlobUtil.formatSpatialPointList(foes, TELEMETRY_CAP));
+            telemetry.addData("Intake blocked", spatial.intakeBlocked());
+            VidarOffensiveLaneAnalysis lane = spatial.offensiveLaneAnalysis();
+            telemetry.addData("Offensive lane",
+                    String.format("%s (L%d C%d R%d)",
+                            lane.recommended,
+                            lane.leftCount,
+                            lane.centerCount,
+                            lane.rightCount));
+            telemetry.addData("Tracks", spatial.trackCount());
+            if (spatial.isMotionTrackingActive() && spatial.trackCount() > 0) {
+                List<VidarSpatialTrack> elementTracks =
+                        spatial.worldModel().getTracks(VidarWorldModel.Kind.ELEMENT);
+                if (!elementTracks.isEmpty()) {
+                    telemetry.addData("Sample track",
+                            VidarBlobUtil.formatWorldTrack(elementTracks.get(0)));
+                }
+            }
             telemetry.update();
         }
 
-        leftDrive.setPower(0);
-        rightDrive.setPower(0);
-        vision.close();
-    }
-
-    private static double clamp(double v, double lo, double hi) {
-        return Math.max(lo, Math.min(hi, v));
+        spatial.close();
     }
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarBlobUtil.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarBlobUtil.java
@@ -3,6 +3,8 @@ package org.firstinspires.ftc.teamcode.vidar;
 import org.firstinspires.ftc.vision.opencv.ColorBlobLocatorProcessor;
 import org.opencv.core.RotatedRect;
 
+import java.util.List;
+
 /**
  * Shared helpers for logging and geometry — keeps OpModes short for teaching.
  */
@@ -91,18 +93,80 @@ public final class VidarBlobUtil {
                 plate.aspectRatio);
     }
 
-    public static String formatWorldTrack(VidarWorldModel.Track track) {
+    public static String formatWorldTrack(VidarSpatialTrack track) {
         if (track == null) {
             return "none";
         }
         return String.format(
-                "%s @ (%.0f, %.0f) in · %.0f° · conf=%.0f%% · age=%.1fs",
+                "#%d %s @ (%.0f, %.0f) in · %.0f° · v=%.1f,%.1f in/s · conf=%.0f%% · miss=%d",
+                track.trackId,
                 track.kind.name(),
                 track.robotX,
                 track.robotY,
                 track.bearingDeg(),
+                track.velFieldXInPerSec,
+                track.velFieldYInPerSec,
                 track.confidence * 100,
-                0.0);
+                track.missCount);
+    }
+
+    public static String formatSpatialPoint(VidarSpatialPoint point) {
+        if (point == null) {
+            return "none";
+        }
+        String trackTag = point.trackId >= 0 ? String.format(" #%d", point.trackId) : "";
+        String velTag = point.source == VidarSpatialPoint.Source.REMEMBERED
+                && point.speedFieldInPerSec() > 0.1
+                ? String.format(" · v=%.1f,%.1f", point.velFieldXInPerSec, point.velFieldYInPerSec)
+                : "";
+        return String.format(
+                "%s/%s%s%s fwd=%s left=%s · %.0f° · range=%s · conf=%.0f%% · %s%s",
+                point.kind.name(),
+                point.source.name(),
+                trackTag,
+                formatElementLabel(point),
+                fmtIn(point.robotX),
+                fmtIn(point.robotY),
+                point.bearingDeg(),
+                fmtIn(point.range),
+                point.confidence * 100,
+                point.cameraName.isEmpty() ? "—" : point.cameraName,
+                velTag);
+    }
+
+    private static String formatElementLabel(VidarSpatialPoint point) {
+        if (point.kind != VidarSpatialPoint.Kind.ELEMENT) {
+            return " ";
+        }
+        if (!point.elementId.isEmpty() && point.occurrenceRank >= 0) {
+            return " " + point.elementId + "#" + point.occurrenceRank + " ";
+        }
+        if (!point.elementId.isEmpty()) {
+            return " " + point.elementId + " ";
+        }
+        if (point.occurrenceRank >= 0) {
+            return " rank=" + point.occurrenceRank + " ";
+        }
+        return " ";
+    }
+
+    public static String formatSpatialPointList(List<VidarSpatialPoint> points, int maxShown) {
+        if (points == null || points.isEmpty()) {
+            return "none";
+        }
+        int limit = Math.max(1, maxShown);
+        StringBuilder sb = new StringBuilder();
+        int count = Math.min(limit, points.size());
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                sb.append(" | ");
+            }
+            sb.append(formatSpatialPoint(points.get(i)));
+        }
+        if (points.size() > count) {
+            sb.append(String.format(" (+ %d more)", points.size() - count));
+        }
+        return sb.toString();
     }
 
     public static String formatBlob(ColorBlobLocatorProcessor.Blob blob) {
@@ -122,12 +186,13 @@ public final class VidarBlobUtil {
         if (element == null) {
             return "none";
         }
+        String idTag = element.elementId.isEmpty() ? "" : element.elementId + " · ";
         if (Double.isNaN(element.range)) {
-            return String.format("(%.0f, %.0f) r=%.0f conf=%.0f%%",
-                    element.cx, element.cy, element.radiusPx, element.confidence * 100);
+            return String.format("%s(%.0f, %.0f) r=%.0f conf=%.0f%%",
+                    idTag, element.cx, element.cy, element.radiusPx, element.confidence * 100);
         }
-        return String.format("(%.0f, %.0f) r=%.0f range=%.1f in conf=%.0f%%",
-                element.cx, element.cy, element.radiusPx, element.range, element.confidence * 100);
+        return String.format("%s(%.0f, %.0f) r=%.0f range=%.1f in conf=%.0f%%",
+                idTag, element.cx, element.cy, element.radiusPx, element.range, element.confidence * 100);
     }
 
     public static String formatElementDetail(VidarElementObservation element) {
@@ -201,20 +266,5 @@ public final class VidarBlobUtil {
                 scout.apparentWidthPx,
                 scout.scoutConfidence * 100,
                 scout.cameraName);
-    }
-
-    /** Forward drive power from fused range (0 when at pickup distance). */
-    public static double rangeDrivePower(VidarElementObservation element) {
-        if (element == null || Double.isNaN(element.range)) {
-            return 0;
-        }
-        if (element.range <= VidarConfig.PICKUP_STOP) {
-            return 0;
-        }
-        if (element.range > VidarConfig.SEEK_MAX_RANGE_IN) {
-            return 0;
-        }
-        double raw = (element.range - VidarConfig.PICKUP_STOP) * VidarConfig.RANGE_DRIVE_GAIN;
-        return Math.min(VidarConfig.SEEK_DRIVE_POWER, raw);
     }
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarConfig.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarConfig.java
@@ -214,24 +214,7 @@ public final class VidarConfig {
      */
     public static final boolean USE_CENTER_ROI = false;
 
-    // --- Drive tuning for VidarTeleOp (optional motor names in config) ---
-    public static final String LEFT_DRIVE = "left";
-    public static final String RIGHT_DRIVE = "right";
-    public static final double DRIVE_SPEED = 0.5;
-    /** If a robot blob is within this many pixels of frame center, nudge away. */
-    public static final double AVOID_CENTER_RADIUS = 60;
-    public static final double AVOID_TURN_POWER = 0.35;
-
-    // --- Auto seek (VidarAutoSeekOpMode) ---
-    public static final double SEEK_TURN_GAIN = 0.45;
-    public static final double SEEK_DRIVE_POWER = 0.35;
-    public static final double SEEK_ALIGNED_PIXELS = 25;
-    public static final double SEARCH_TURN_POWER = 0.15;
-
-    /** Stop forward motion when fused range is at or below this (inches). */
-    public static final double PICKUP_STOP = 14.0;
-
-    /** VisionPortal resolution — 480p on all cameras when tags are enabled. */
+    // --- Alliance plate detection (rotated rect + white digits) ---
     public static Size portalCameraResolution() {
         if (VidarTagConfig.ENABLED) {
             return VidarTagConfig.CAPTURE_RESOLUTION;
@@ -259,12 +242,6 @@ public final class VidarConfig {
                 0, half, s.getWidth(), s.getHeight());
     }
 
-    /** Do not drive toward elements beyond this fused range. */
-    public static final double SEEK_MAX_RANGE_IN = 72.0;
-
-    /** Forward power scale: (range - PICKUP_STOP) * gain, clamped to SEEK_DRIVE_POWER. */
-    public static final double RANGE_DRIVE_GAIN = 0.025;
-
     // --- Alliance plate detection (rotated rect + white digits) ---
     public static final double PLATE_MIN_AREA_PX = 120;
     public static final double PLATE_MAX_AREA_PX = 12000;
@@ -285,12 +262,34 @@ public final class VidarConfig {
     public static final double MIN_PLATE_CONFIDENCE = 0.35;
 
     // --- Short-term world model (VidarWorldModel) ---
+    /** When false, skip motion correction and track memory (live vision only). */
+    public static final boolean WORLD_MOTION_TRACKING_ENABLED = true;
     public static final double WORLD_ELEMENT_TTL_SEC = 2.5;
     public static final double WORLD_FOE_TTL_SEC = 3.0;
     public static final double WORLD_ALLY_TTL_SEC = 4.0;
+    /** @deprecated use {@link #WORLD_TRACK_GATE_RADIUS_IN} for association */
     public static final double WORLD_MERGE_RADIUS_IN = 8.0;
     public static final double WORLD_BLOCK_RANGE_IN = 36.0;
     public static final double WORLD_BLOCK_CONE_DEG = 35.0;
+
+    /** Association gate — detection must fall within this of predicted robot position (inches). */
+    public static final double WORLD_TRACK_GATE_RADIUS_IN = 12.0;
+    public static final double WORLD_TRACK_GATE_RADIUS_FOE_IN = 18.0;
+    /** Position filter on match: new = alpha * det + (1-alpha) * pred. */
+    public static final double WORLD_TRACK_POS_ALPHA = 0.7;
+    public static final double WORLD_TRACK_VEL_ALPHA = 0.35;
+    public static final double WORLD_TRACK_MIN_DT_SEC = 0.05;
+    public static final double WORLD_TRACK_MAX_DT_SEC = 0.5;
+    public static final double WORLD_TRACK_STATIC_SPEED_IN_PER_SEC = 2.0;
+    public static final int WORLD_TRACK_STATIC_FRAMES = 5;
+    public static final double WORLD_TRACK_MOVING_SPEED_IN_PER_SEC = 4.0;
+    public static final int WORLD_TRACK_MAX_MISS_FRAMES = 8;
+
+    // --- Offensive lane helper (VidarOffensiveLaneAnalysis) ---
+    /** Max robot-frame range for foe lane counts (+X forward). */
+    public static final double OFFENSIVE_LANE_MAX_RANGE_IN = 48.0;
+    /** Half-width of forward cone; split into three equal lanes. */
+    public static final double OFFENSIVE_LANE_CONE_HALF_DEG = 35.0;
 
     // --- Element density map (VidarElementDensityMap) ---
     /** Grid cell size in robot frame (+X forward, +Y left). */

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarDiscoverOpMode.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarDiscoverOpMode.java
@@ -25,11 +25,11 @@ public class VidarDiscoverOpMode extends LinearOpMode {
     public void runOpMode() {
         VidarAllianceSelector alliance = new VidarAllianceSelector(hardwareMap);
         Pose2D[] odomHolder = {new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0)};
-        VidarMultiVision vision = new VidarMultiVision(hardwareMap, () -> odomHolder[0], alliance::get);
-        VidarWorldModel world = new VidarWorldModel(() -> odomHolder[0], vision::getFusedFieldPose);
-        vision.setFieldPosePrior(odomHolder[0]);
+        VidarSpatial spatial = VidarSpatial.create(hardwareMap, () -> odomHolder[0], alliance::get);
+        spatial.setFieldPosePrior(odomHolder[0]);
+        VidarMultiVision vision = spatial.vision();
 
-        telemetry.addLine("ViDAR Discover — " + vision.getCameraCount() + " cam(s) @ 640×480 tic-toc");
+        telemetry.addLine("ViDAR Discover — " + spatial.cameraCount() + " cam(s) @ 640×480 tic-toc");
         telemetry.addLine("INIT: Y=RED B=BLUE (or color sensor on own sign)");
         telemetry.addLine("Run: Back toggles alliance · A = tag sample");
         telemetry.update();
@@ -51,35 +51,30 @@ public class VidarDiscoverOpMode extends LinearOpMode {
             }
             lastA = gamepad1.a;
 
-            long now = System.nanoTime();
-            vision.update();
-            world.update(vision, now);
+            spatial.update();
 
             VidarElementObservation element = vision.getBestElement();
             VidarPlateObservation plate = vision.getBestPlate();
             VidarTagScoutResult scout = vision.getLastTagScout();
             VidarTagObservation tag = vision.getLatestTag();
-            Pose2D fieldNow = vision.getFusedFieldPose();
-            if (fieldNow == null && tag != null) {
-                fieldNow = vision.getBackdatedFieldPose(odomHolder[0], odomHolder[0]);
-            }
+            Pose2D fieldNow = spatial.fieldPose();
             VidarAlliance ours = alliance.get();
 
-            telemetry.addData("Cameras", vision.getCameraCount());
-            telemetry.addData("FPS cam1", vision.getCameraCount() > 0
+            telemetry.addData("Cameras", spatial.cameraCount());
+            telemetry.addData("FPS cam1", spatial.cameraCount() > 0
                     ? String.format("%.1f", vision.camera(0).portalFps()) : "—");
             telemetry.addData("Alliance", alliance.formatStatus());
             telemetry.addData("Element", VidarBlobUtil.formatElement(element));
             telemetry.addData("Element detail", VidarBlobUtil.formatElementDetail(element));
+            telemetry.addData("Spatial live", VidarBlobUtil.formatSpatialPoint(spatial.bestElement()));
+            telemetry.addData("Spatial remembered", VidarBlobUtil.formatSpatialPoint(spatial.nearestElement()));
             telemetry.addData("Calibration", VidarBlobUtil.formatCalibrationDiagnostics(
                     vision.calibrationDiagnostics().toTelemetryMap()));
             telemetry.addData("Plate", VidarBlobUtil.formatPlate(plate, ours));
             telemetry.addData("Plate detail", VidarBlobUtil.formatPlateDetail(plate));
             telemetry.addData("Foe", VidarBlobUtil.formatPlate(vision.getBestFoe(), ours));
-            telemetry.addData("World tracks", world.trackCount());
-            telemetry.addData("Nearest element", VidarBlobUtil.formatWorldTrack(world.nearestElement()));
-            telemetry.addData("Nearest foe", VidarBlobUtil.formatWorldTrack(world.nearestFoe()));
-            telemetry.addData("Intake blocked", world.intakeBlocked());
+            telemetry.addData("World tracks", spatial.trackCount());
+            telemetry.addData("Intake blocked", spatial.intakeBlocked());
             telemetry.addData("Tag scout", scout == null ? "none"
                     : String.format("(%.0f,%.0f) w=%.0f %s", scout.cx, scout.cy, scout.widthPx, scout.band));
             telemetry.addData("Tag fix", VidarBlobUtil.formatTag(tag));
@@ -97,6 +92,6 @@ public class VidarDiscoverOpMode extends LinearOpMode {
             telemetry.update();
         }
 
-        vision.close();
+        spatial.close();
     }
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarElementObservation.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarElementObservation.java
@@ -6,6 +6,8 @@ package org.firstinspires.ftc.teamcode.vidar;
  */
 public final class VidarElementObservation {
 
+    /** Season element id from {@code season.json} (e.g. {@code artifact_purple}). */
+    public final String elementId;
     public final String cameraName;
     public final long captureTimeNanos;
     /** Image center in full-frame coordinates. */
@@ -51,13 +53,14 @@ public final class VidarElementObservation {
             double dSize, double dFloor,
             VidarRangeResult rangeResult,
             double robotX, double robotY) {
-        this(cameraName, captureTimeNanos, cx, cy, boundingWidthPx, boundingHeightPx,
+        this("", cameraName, captureTimeNanos, cx, cy, boundingWidthPx, boundingHeightPx,
                 fittedCx, fittedCy, radiusPx, areaPx, aspectRatio, circularity, fillRatio,
                 interiorValidationScore, detectorType, confidence, range, rangeUncertainty,
                 dSize, dFloor, Double.NaN, rangeResult, robotX, robotY, 0);
     }
 
     public VidarElementObservation(
+            String elementId,
             String cameraName,
             long captureTimeNanos,
             double cx, double cy,
@@ -72,6 +75,7 @@ public final class VidarElementObservation {
             VidarRangeResult rangeResult,
             double robotX, double robotY,
             int houghVotes) {
+        this.elementId = elementId == null ? "" : elementId;
         this.cameraName = cameraName;
         this.captureTimeNanos = captureTimeNanos;
         this.cx = cx;

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarElementOccurrenceRank.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarElementOccurrenceRank.java
@@ -1,0 +1,111 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Assigns occurrence rank 0, 1, 2… within each season {@code elementId} by distance.
+ */
+public final class VidarElementOccurrenceRank {
+
+    private VidarElementOccurrenceRank() {}
+
+    public static List<VidarSpatialPoint> assignPerType(List<VidarSpatialPoint> points) {
+        if (points == null || points.isEmpty()) {
+            return points == null ? new ArrayList<VidarSpatialPoint>() : points;
+        }
+        List<VidarSpatialPoint> elements = new ArrayList<>();
+        List<VidarSpatialPoint> other = new ArrayList<>();
+        for (VidarSpatialPoint point : points) {
+            if (point.kind == VidarSpatialPoint.Kind.ELEMENT) {
+                elements.add(point);
+            } else {
+                other.add(point);
+            }
+        }
+        List<VidarSpatialPoint> ranked = rankElementPoints(elements);
+        List<VidarSpatialPoint> out = new ArrayList<>(ranked.size() + other.size());
+        out.addAll(ranked);
+        out.addAll(other);
+        return out;
+    }
+
+    public static List<VidarTrackDetection> assignDetectionRanks(List<VidarTrackDetection> detections) {
+        if (detections == null || detections.isEmpty()) {
+            return detections == null ? new ArrayList<VidarTrackDetection>() : detections;
+        }
+        List<VidarTrackDetection> elements = new ArrayList<>();
+        List<VidarTrackDetection> other = new ArrayList<>();
+        for (VidarTrackDetection det : detections) {
+            if (det.kind == VidarWorldModel.Kind.ELEMENT) {
+                elements.add(det);
+            } else {
+                other.add(det);
+            }
+        }
+        List<VidarTrackDetection> ranked = rankDetections(elements);
+        List<VidarTrackDetection> out = new ArrayList<>(ranked.size() + other.size());
+        out.addAll(ranked);
+        out.addAll(other);
+        return out;
+    }
+
+    private static List<VidarSpatialPoint> rankElementPoints(List<VidarSpatialPoint> elements) {
+        Map<String, List<VidarSpatialPoint>> grouped = groupPointsByElementId(elements);
+        List<VidarSpatialPoint> out = new ArrayList<>(elements.size());
+        for (List<VidarSpatialPoint> group : grouped.values()) {
+            Collections.sort(group, Comparator.comparingDouble(VidarSpatialPoint::distance));
+            for (int i = 0; i < group.size(); i++) {
+                out.add(group.get(i).withOccurrenceRank(i));
+            }
+        }
+        Collections.sort(out, Comparator.comparingDouble(VidarSpatialPoint::distance));
+        return out;
+    }
+
+    private static List<VidarTrackDetection> rankDetections(List<VidarTrackDetection> elements) {
+        Map<String, List<VidarTrackDetection>> grouped = groupDetectionsByElementId(elements);
+        List<VidarTrackDetection> out = new ArrayList<>(elements.size());
+        for (List<VidarTrackDetection> group : grouped.values()) {
+            Collections.sort(group, Comparator.comparingDouble(VidarTrackDetection::distance));
+            for (int i = 0; i < group.size(); i++) {
+                out.add(group.get(i).withOccurrenceRank(i));
+            }
+        }
+        return out;
+    }
+
+    private static Map<String, List<VidarSpatialPoint>> groupPointsByElementId(
+            List<VidarSpatialPoint> elements) {
+        Map<String, List<VidarSpatialPoint>> grouped = new HashMap<>();
+        for (VidarSpatialPoint point : elements) {
+            String key = point.elementId.isEmpty() ? "" : point.elementId;
+            List<VidarSpatialPoint> bucket = grouped.get(key);
+            if (bucket == null) {
+                bucket = new ArrayList<>();
+                grouped.put(key, bucket);
+            }
+            bucket.add(point);
+        }
+        return grouped;
+    }
+
+    private static Map<String, List<VidarTrackDetection>> groupDetectionsByElementId(
+            List<VidarTrackDetection> elements) {
+        Map<String, List<VidarTrackDetection>> grouped = new HashMap<>();
+        for (VidarTrackDetection det : elements) {
+            String key = det.elementId.isEmpty() ? "" : det.elementId;
+            List<VidarTrackDetection> bucket = grouped.get(key);
+            if (bucket == null) {
+                bucket = new ArrayList<>();
+                grouped.put(key, bucket);
+            }
+            bucket.add(det);
+        }
+        return grouped;
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarGeometry.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarGeometry.java
@@ -484,8 +484,10 @@ public final class VidarGeometry {
         double[] robotPoint = floorPointInRobot(cx, cy, rangeResult.distance, profile);
         double robotX = robotPoint[0];
         double robotY = robotPoint[1];
+        String elementId = activeElement.id == null ? "" : activeElement.id;
 
         return new VidarElementObservation(
+                elementId,
                 cameraName,
                 captureTimeNanos,
                 cx, cy,

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarMultiVision.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarMultiVision.java
@@ -13,7 +13,9 @@ import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -262,7 +264,30 @@ public class VidarMultiVision {
             calibrationDiagnostics.recordObservationAge(
                     (updateTimeNanos - bestElement.captureTimeNanos) / 1_000_000.0);
         }
+        refreshFusedFieldPose();
         return latestFrame;
+    }
+
+    private void refreshFusedFieldPose() {
+        if (odomSupplier == null) {
+            fusedFieldPose = localization.lastFusedFieldPose();
+            return;
+        }
+        Pose2D odomNow = odomSupplier.get();
+        Pose2D odomAtCapture = null;
+        if (latestTag != null && latestTag.captureTimeNanos > 0) {
+            odomAtCapture = odomHistory.at(latestTag.captureTimeNanos);
+        }
+        if (odomAtCapture == null) {
+            odomAtCapture = odomNow;
+        }
+        Pose2D fused = localization.fusedFieldPoseNow(
+                latestTag, latestScoutObservation, odomAtCapture, odomNow);
+        if (fused != null) {
+            fusedFieldPose = fused;
+        } else {
+            fusedFieldPose = localization.lastFusedFieldPose();
+        }
     }
 
     /** Last snapshot from {@link #update()} — safe to read multiple times per cycle. */
@@ -564,6 +589,27 @@ public class VidarMultiVision {
             }
         }
         return best;
+    }
+
+    /** Best per-season-type element observations merged across cameras. */
+    public Map<String, VidarElementObservation> getGameElements() {
+        Map<String, VidarElementObservation> merged = new HashMap<>();
+        for (VidarVision camera : cameras) {
+            if (camera == null || camera.isFailed()) {
+                continue;
+            }
+            for (Map.Entry<String, VidarElementObservation> entry : camera.getGameElements().entrySet()) {
+                VidarElementObservation obs = temporalFilter.filterElement(entry.getValue());
+                if (obs == null) {
+                    continue;
+                }
+                VidarElementObservation existing = merged.get(entry.getKey());
+                if (existing == null || elementScore(obs) > elementScore(existing)) {
+                    merged.put(entry.getKey(), obs);
+                }
+            }
+        }
+        return merged;
     }
 
     public VidarPlateObservation getBestPlate() {

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarMultiVision.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarMultiVision.java
@@ -55,6 +55,7 @@ public class VidarMultiVision {
     private VidarTagScoutObservation latestScoutObservation;
     private VidarTagScoutResult lastTagScout;
     private Pose2D fusedFieldPose;
+    private Pose2D odomAtLastFusedFieldPose;
     private volatile VidarObservationFrame latestFrame = VidarObservationFrame.empty();
 
     public VidarMultiVision(com.qualcomm.robotcore.hardware.HardwareMap hardwareMap) {
@@ -285,9 +286,43 @@ public class VidarMultiVision {
                 latestTag, latestScoutObservation, odomAtCapture, odomNow);
         if (fused != null) {
             fusedFieldPose = fused;
+            odomAtLastFusedFieldPose = odomNow;
         } else {
             fusedFieldPose = localization.lastFusedFieldPose();
         }
+    }
+
+    /**
+     * Field pose for motion-corrected world tracks — extrapolates tag fusion with odom between
+     * decode cycles. When odom is configured but no tag anchor exists yet, uses odom directly
+     * (Pinpoint / Pedro field-relative pose).
+     */
+    public Pose2D getFieldPoseForMotionTracking() {
+        if (odomSupplier == null) {
+            if (fusedFieldPose != null) {
+                return fusedFieldPose;
+            }
+            return localization.fieldPosePrior();
+        }
+        Pose2D odomNow = odomSupplier.get();
+        if (odomNow == null) {
+            return fusedFieldPose;
+        }
+        if (latestTag != null && latestTag.fieldPoseAtCapture != null) {
+            Pose2D odomAtCapture = odomHistory.at(latestTag.captureTimeNanos);
+            if (odomAtCapture == null) {
+                odomAtCapture = odomNow;
+            }
+            Pose2D backdated = VidarMotionCorrection.tagFieldNow(latestTag, odomAtCapture, odomNow);
+            if (backdated != null) {
+                return backdated;
+            }
+        }
+        Pose2D anchor = localization.lastFusedFieldPose();
+        if (anchor != null && odomAtLastFusedFieldPose != null) {
+            return VidarMotionCorrection.robotFieldPoseNow(anchor, odomAtLastFusedFieldPose, odomNow);
+        }
+        return odomNow;
     }
 
     /** Last snapshot from {@link #update()} — safe to read multiple times per cycle. */

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarOffensiveLane.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarOffensiveLane.java
@@ -1,0 +1,10 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+/**
+ * Forward offensive lane relative to robot heading (+X forward).
+ */
+public enum VidarOffensiveLane {
+    LEFT,
+    CENTER,
+    RIGHT
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarOffensiveLaneAnalysis.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarOffensiveLaneAnalysis.java
@@ -1,0 +1,107 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Foe density in the forward cone split into left / center / right lanes.
+ *
+ * <p>Teams use {@link #recommended()} to pick a lane with the fewest nearby foes.
+ */
+public final class VidarOffensiveLaneAnalysis {
+
+    public final int leftCount;
+    public final int centerCount;
+    public final int rightCount;
+    public final VidarOffensiveLane recommended;
+    public final double maxRangeIn;
+    public final double coneHalfDeg;
+
+    private VidarOffensiveLaneAnalysis(
+            int leftCount,
+            int centerCount,
+            int rightCount,
+            VidarOffensiveLane recommended,
+            double maxRangeIn,
+            double coneHalfDeg) {
+        this.leftCount = leftCount;
+        this.centerCount = centerCount;
+        this.rightCount = rightCount;
+        this.recommended = recommended;
+        this.maxRangeIn = maxRangeIn;
+        this.coneHalfDeg = coneHalfDeg;
+    }
+
+    public static VidarOffensiveLaneAnalysis fromFoes(List<VidarSpatialPoint> foes) {
+        return fromFoes(
+                foes,
+                VidarConfig.OFFENSIVE_LANE_MAX_RANGE_IN,
+                VidarConfig.OFFENSIVE_LANE_CONE_HALF_DEG);
+    }
+
+    public static VidarOffensiveLaneAnalysis fromFoes(
+            List<VidarSpatialPoint> foes,
+            double maxRangeIn,
+            double coneHalfDeg) {
+        Map<VidarOffensiveLane, List<VidarSpatialPoint>> buckets = new EnumMap<>(VidarOffensiveLane.class);
+        for (VidarOffensiveLane lane : VidarOffensiveLane.values()) {
+            buckets.put(lane, new ArrayList<>());
+        }
+
+        if (foes != null) {
+            double third = coneHalfDeg / 3.0;
+            for (VidarSpatialPoint foe : foes) {
+                if (foe == null || !foe.isValid()) {
+                    continue;
+                }
+                if (foe.distance() > maxRangeIn) {
+                    continue;
+                }
+                double bearing = foe.bearingDeg();
+                if (Math.abs(bearing) > coneHalfDeg) {
+                    continue;
+                }
+                VidarOffensiveLane lane;
+                if (bearing < -third) {
+                    lane = VidarOffensiveLane.LEFT;
+                } else if (bearing > third) {
+                    lane = VidarOffensiveLane.RIGHT;
+                } else {
+                    lane = VidarOffensiveLane.CENTER;
+                }
+                buckets.get(lane).add(foe);
+            }
+        }
+
+        int left = buckets.get(VidarOffensiveLane.LEFT).size();
+        int center = buckets.get(VidarOffensiveLane.CENTER).size();
+        int right = buckets.get(VidarOffensiveLane.RIGHT).size();
+        VidarOffensiveLane recommended = pickLane(left, center, right);
+        return new VidarOffensiveLaneAnalysis(left, center, right, recommended, maxRangeIn, coneHalfDeg);
+    }
+
+    private static VidarOffensiveLane pickLane(int left, int center, int right) {
+        int min = Math.min(left, Math.min(center, right));
+        if (center == min) {
+            return VidarOffensiveLane.CENTER;
+        }
+        if (left == min) {
+            return VidarOffensiveLane.LEFT;
+        }
+        return VidarOffensiveLane.RIGHT;
+    }
+
+    public int count(VidarOffensiveLane lane) {
+        switch (lane) {
+            case LEFT:
+                return leftCount;
+            case CENTER:
+                return centerCount;
+            case RIGHT:
+            default:
+                return rightCount;
+        }
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
@@ -70,15 +70,15 @@ public final class VidarSpatial {
             Supplier<VidarAlliance> allianceSupplier) {
         VidarMultiVision vision = new VidarMultiVision(
                 hardwareMap, robot, season, odomSupplier, allianceSupplier);
-        VidarWorldModel world = new VidarWorldModel(
-                odomSupplier,
-                () -> vision.getFusedFieldPose());
-        return new VidarSpatial(vision, world, odomSupplier, null);
+        VidarWorldModel world = new VidarWorldModel(odomSupplier, null);
+        VidarSpatial spatial = new VidarSpatial(vision, world, odomSupplier, null);
+        world.setFieldPoseSupplier(spatial::fieldPoseForWorldTracks);
+        return spatial;
     }
 
     public void setFieldPoseSupplier(Supplier<Pose2D> supplier) {
         this.fieldPoseSupplier = supplier;
-        world.setFieldPoseSupplier(supplier != null ? supplier : vision::getFusedFieldPose);
+        world.setFieldPoseSupplier(this::fieldPoseForWorldTracks);
     }
 
     public void setFieldPosePrior(Pose2D prior) {
@@ -253,6 +253,17 @@ public final class VidarSpatial {
 
     public void close() {
         vision.close();
+    }
+
+    /** Team override first, then odom-extrapolated field pose for world tracks. */
+    Pose2D fieldPoseForWorldTracks() {
+        if (fieldPoseSupplier != null) {
+            Pose2D external = fieldPoseSupplier.get();
+            if (external != null) {
+                return external;
+            }
+        }
+        return vision.getFieldPoseForMotionTracking();
     }
 
     private static void addUnique(List<VidarSpatialPoint> list, VidarSpatialPoint candidate) {

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
@@ -1,0 +1,294 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+import org.firstinspires.ftc.teamcode.VidarTeamConfig;
+import org.firstinspires.ftc.teamcode.vidar.config.VidarRobotConfig;
+import org.firstinspires.ftc.teamcode.vidar.config.VidarSeasonConfig;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Pedro-style facade for ViDAR spatial knowledge — one object, one {@link #update()} per loop.
+ *
+ * <p>Three spatial groups — {@link #elements()}, {@link #allies()}, {@link #foes()} — plus pose.
+ * ViDAR never commands motors.
+ *
+ * <p>Motion-corrected track memory requires an odom supplier at {@link #create} and
+ * {@link #setMotionTrackingEnabled(boolean)} true (default from {@link VidarConfig}).
+ * Without odom, queries return live camera detections only.
+ */
+public final class VidarSpatial {
+
+    private final VidarMultiVision vision;
+    private final VidarWorldModel world;
+    private final Supplier<Pose2D> odomSupplier;
+    private Supplier<Pose2D> fieldPoseSupplier;
+
+    private VidarSpatial(
+            VidarMultiVision vision,
+            VidarWorldModel world,
+            Supplier<Pose2D> odomSupplier,
+            Supplier<Pose2D> fieldPoseSupplier) {
+        this.vision = vision;
+        this.world = world;
+        this.odomSupplier = odomSupplier;
+        this.fieldPoseSupplier = fieldPoseSupplier;
+    }
+
+    public static VidarSpatial create(HardwareMap hardwareMap) {
+        return create(hardwareMap, null, null);
+    }
+
+    public static VidarSpatial create(
+            HardwareMap hardwareMap,
+            Supplier<Pose2D> odomSupplier,
+            Supplier<VidarAlliance> allianceSupplier) {
+        try {
+            return create(
+                    hardwareMap,
+                    VidarTeamConfig.loadRobot(hardwareMap),
+                    VidarTeamConfig.loadSeason(hardwareMap),
+                    odomSupplier,
+                    allianceSupplier);
+        } catch (IOException e) {
+            return create(hardwareMap, null, null, odomSupplier, allianceSupplier);
+        }
+    }
+
+    public static VidarSpatial create(
+            HardwareMap hardwareMap,
+            VidarRobotConfig robot,
+            VidarSeasonConfig season,
+            Supplier<Pose2D> odomSupplier,
+            Supplier<VidarAlliance> allianceSupplier) {
+        VidarMultiVision vision = new VidarMultiVision(
+                hardwareMap, robot, season, odomSupplier, allianceSupplier);
+        VidarWorldModel world = new VidarWorldModel(
+                odomSupplier,
+                () -> vision.getFusedFieldPose());
+        return new VidarSpatial(vision, world, odomSupplier, null);
+    }
+
+    public void setFieldPoseSupplier(Supplier<Pose2D> supplier) {
+        this.fieldPoseSupplier = supplier;
+        world.setFieldPoseSupplier(supplier != null ? supplier : vision::getFusedFieldPose);
+    }
+
+    public void setFieldPosePrior(Pose2D prior) {
+        vision.setFieldPosePrior(prior);
+    }
+
+    /** Enable/disable motion-corrected world tracks (no-op without odom supplier). */
+    public void setMotionTrackingEnabled(boolean enabled) {
+        world.setMotionTrackingEnabled(enabled);
+    }
+
+    public boolean isMotionTrackingEnabled() {
+        return world.isMotionTrackingEnabled();
+    }
+
+    public boolean isOdomConfigured() {
+        return odomSupplier != null;
+    }
+
+    /** True when world-model motion correction and track memory are active. */
+    public boolean isMotionTrackingActive() {
+        return world.isMotionTrackingActive();
+    }
+
+    public void update() {
+        if (odomSupplier != null) {
+            vision.recordOdom(odomSupplier.get());
+        }
+        vision.update();
+        world.update(vision, System.nanoTime());
+    }
+
+    public VidarCorrectedFrame updateCorrected() {
+        if (odomSupplier != null) {
+            vision.recordOdom(odomSupplier.get());
+        }
+        VidarCorrectedFrame corrected = vision.updateCorrected();
+        world.update(vision, System.nanoTime());
+        return corrected;
+    }
+
+    /**
+     * Season game elements — fused rank 0 = closest/easiest, plus remembered tracks when motion
+     * tracking is active. Sorted nearest-first.
+     */
+    public List<VidarSpatialPoint> elements() {
+        List<VidarSpatialPoint> out = new ArrayList<>();
+        VidarRankedElementFrame ranked = vision.getRankedElements();
+        if (ranked != null) {
+            for (int i = 0; i < ranked.count(); i++) {
+                VidarElementObservation obs = ranked.at(i);
+                if (obs == null || obs.confidence < VidarConfig.MIN_ELEMENT_CONFIDENCE) {
+                    continue;
+                }
+                addUnique(out, VidarSpatialPoint.fromElement(obs));
+            }
+        }
+        if (world.isMotionTrackingActive()) {
+            for (VidarSpatialTrack track : world.getTracks(VidarWorldModel.Kind.ELEMENT)) {
+                addUnique(out, VidarSpatialPoint.fromTrack(track));
+            }
+        }
+        return VidarElementOccurrenceRank.assignPerType(out);
+    }
+
+    /** Friendly alliance plates — live plus remembered tracks when motion tracking is active. */
+    public List<VidarSpatialPoint> allies() {
+        List<VidarSpatialPoint> out = new ArrayList<>();
+        addUnique(out, bestAlly());
+        if (world.isMotionTrackingActive()) {
+            for (VidarSpatialTrack track : world.getTracks(VidarWorldModel.Kind.ALLY)) {
+                addUnique(out, VidarSpatialPoint.fromTrack(track));
+            }
+        }
+        sortByDistance(out);
+        return out;
+    }
+
+    /** Opponent plates — live plus remembered tracks when motion tracking is active. */
+    public List<VidarSpatialPoint> foes() {
+        List<VidarSpatialPoint> out = new ArrayList<>();
+        addUnique(out, bestFoe());
+        if (world.isMotionTrackingActive()) {
+            for (VidarSpatialTrack track : world.getTracks(VidarWorldModel.Kind.FOE)) {
+                addUnique(out, VidarSpatialPoint.fromTrack(track));
+            }
+        }
+        sortByDistance(out);
+        return out;
+    }
+
+    public VidarSpatialPoint bestElement() {
+        return VidarSpatialPoint.fromElement(vision.getBestElement());
+    }
+
+    public VidarSpatialPoint nearestElement() {
+        return world.isMotionTrackingActive()
+                ? VidarSpatialPoint.fromTrack(world.nearestElement())
+                : bestElement();
+    }
+
+    public VidarSpatialPoint bestFoe() {
+        return VidarSpatialPoint.fromPlate(vision.getBestFoe(), VidarSpatialPoint.Kind.FOE);
+    }
+
+    public VidarSpatialPoint nearestFoe() {
+        if (world.isMotionTrackingActive()) {
+            return VidarSpatialPoint.fromTrack(world.nearestFoe());
+        }
+        return bestFoe();
+    }
+
+    public VidarSpatialPoint bestAlly() {
+        return VidarSpatialPoint.fromPlate(vision.getBestAlly(), VidarSpatialPoint.Kind.ALLY);
+    }
+
+    public Pose2D robotPose() {
+        return odomSupplier != null ? odomSupplier.get() : null;
+    }
+
+    public boolean intakeBlocked() {
+        if (world.isMotionTrackingActive()) {
+            return world.intakeBlocked();
+        }
+        VidarSpatialPoint foe = bestFoe();
+        if (foe == null || !foe.isValid()) {
+            return false;
+        }
+        return foe.distance() <= VidarConfig.WORLD_BLOCK_RANGE_IN
+                && Math.abs(foe.bearingDeg()) <= VidarConfig.WORLD_BLOCK_CONE_DEG;
+    }
+
+    /** Foe counts in left / center / right forward lanes from {@link #foes()}. */
+    public VidarOffensiveLaneAnalysis offensiveLaneAnalysis() {
+        return VidarOffensiveLaneAnalysis.fromFoes(foes());
+    }
+
+    /** Lane with the fewest foes in the forward cone; tie-break center, then left. */
+    public VidarOffensiveLane recommendOffensiveLane() {
+        return offensiveLaneAnalysis().recommended;
+    }
+
+    public int trackCount() {
+        return world.isMotionTrackingActive() ? world.trackCount() : 0;
+    }
+
+    public Pose2D fieldPose() {
+        if (fieldPoseSupplier != null) {
+            Pose2D external = fieldPoseSupplier.get();
+            if (external != null) {
+                return external;
+            }
+        }
+        return vision.getFusedFieldPose();
+    }
+
+    public VidarDistanceUnit distanceUnit() {
+        return vision.distanceUnit();
+    }
+
+    public int cameraCount() {
+        return vision.getCameraCount();
+    }
+
+    public VidarMultiVision vision() {
+        return vision;
+    }
+
+    public VidarWorldModel worldModel() {
+        return world;
+    }
+
+    public void close() {
+        vision.close();
+    }
+
+    private static void addUnique(List<VidarSpatialPoint> list, VidarSpatialPoint candidate) {
+        if (candidate == null || !candidate.isValid()) {
+            return;
+        }
+        if (candidate.trackId >= 0) {
+            for (int i = 0; i < list.size(); i++) {
+                if (list.get(i).trackId == candidate.trackId) {
+                    if (candidate.source == VidarSpatialPoint.Source.LIVE) {
+                        list.set(i, candidate);
+                    }
+                    return;
+                }
+            }
+        }
+        for (int i = 0; i < list.size(); i++) {
+            VidarSpatialPoint existing = list.get(i);
+            if (existing.kind != candidate.kind) {
+                continue;
+            }
+            double separation = Math.hypot(
+                    existing.robotX - candidate.robotX,
+                    existing.robotY - candidate.robotY);
+            if (separation <= VidarConfig.WORLD_TRACK_GATE_RADIUS_IN) {
+                if (candidate.source == VidarSpatialPoint.Source.LIVE
+                        && existing.source == VidarSpatialPoint.Source.REMEMBERED) {
+                    list.set(i, candidate);
+                }
+                return;
+            }
+        }
+        list.add(candidate);
+    }
+
+    private static void sortByDistance(List<VidarSpatialPoint> points) {
+        Collections.sort(points, Comparator.comparingDouble(VidarSpatialPoint::distance));
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatialPoint.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatialPoint.java
@@ -1,0 +1,180 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+/**
+ * Robot-frame spatial sample (+X forward, +Y left) in the active distance unit.
+ *
+ * <p>Produced by {@link VidarSpatial} from live detections or {@link VidarSpatialTrack} memory.
+ */
+public final class VidarSpatialPoint {
+
+    public enum Source {
+        /** Camera sees the target this cycle. */
+        LIVE,
+        /** {@link VidarSpatialTrack} — target may be occluded or off-screen. */
+        REMEMBERED
+    }
+
+    public enum Kind {
+        ELEMENT,
+        FOE,
+        ALLY
+    }
+
+    public final Kind kind;
+    public final Source source;
+    public final int trackId;
+    /** Season element id (e.g. {@code artifact_purple}); empty for plates and unknown tracks. */
+    public final String elementId;
+    /** Fused rank 0 = closest/easiest; {@code -1} when not ranked. */
+    public final int occurrenceRank;
+    public final double robotX;
+    public final double robotY;
+    public final double velFieldXInPerSec;
+    public final double velFieldYInPerSec;
+    public final double range;
+    public final double confidence;
+    public final String cameraName;
+    public final long captureTimeNanos;
+
+    public VidarSpatialPoint(
+            Kind kind,
+            Source source,
+            int trackId,
+            String elementId,
+            int occurrenceRank,
+            double robotX,
+            double robotY,
+            double velFieldXInPerSec,
+            double velFieldYInPerSec,
+            double range,
+            double confidence,
+            String cameraName,
+            long captureTimeNanos) {
+        this.kind = kind;
+        this.source = source;
+        this.trackId = trackId;
+        this.elementId = elementId == null ? "" : elementId;
+        this.occurrenceRank = occurrenceRank;
+        this.robotX = robotX;
+        this.robotY = robotY;
+        this.velFieldXInPerSec = velFieldXInPerSec;
+        this.velFieldYInPerSec = velFieldYInPerSec;
+        this.range = range;
+        this.confidence = confidence;
+        this.cameraName = cameraName == null ? "" : cameraName;
+        this.captureTimeNanos = captureTimeNanos;
+    }
+
+    public double bearingDeg() {
+        return Math.toDegrees(Math.atan2(robotY, robotX));
+    }
+
+    public double distance() {
+        return Math.hypot(robotX, robotY);
+    }
+
+    public double speedFieldInPerSec() {
+        return Math.hypot(velFieldXInPerSec, velFieldYInPerSec);
+    }
+
+    public boolean isValid() {
+        return !Double.isNaN(robotX) && !Double.isNaN(robotY)
+                && confidence > 0 && distance() > 0;
+    }
+
+    public static VidarSpatialPoint fromElement(VidarElementObservation obs) {
+        return fromElement(obs, obs == null ? "" : obs.elementId, -1);
+    }
+
+    public static VidarSpatialPoint fromElement(
+            VidarElementObservation obs, String elementId, int occurrenceRank) {
+        if (obs == null) {
+            return null;
+        }
+        String id = elementId == null || elementId.isEmpty() ? obs.elementId : elementId;
+        return new VidarSpatialPoint(
+                Kind.ELEMENT,
+                Source.LIVE,
+                -1,
+                id,
+                occurrenceRank,
+                obs.robotX,
+                obs.robotY,
+                0,
+                0,
+                obs.range,
+                obs.confidence,
+                obs.cameraName,
+                obs.captureTimeNanos);
+    }
+
+    public VidarSpatialPoint withOccurrenceRank(int occurrenceRank) {
+        return new VidarSpatialPoint(
+                kind,
+                source,
+                trackId,
+                elementId,
+                occurrenceRank,
+                robotX,
+                robotY,
+                velFieldXInPerSec,
+                velFieldYInPerSec,
+                range,
+                confidence,
+                cameraName,
+                captureTimeNanos);
+    }
+
+    public static VidarSpatialPoint fromPlate(VidarPlateObservation plate, Kind kind) {
+        if (plate == null) {
+            return null;
+        }
+        return new VidarSpatialPoint(
+                kind,
+                Source.LIVE,
+                -1,
+                "",
+                -1,
+                plate.robotX,
+                plate.robotY,
+                0,
+                0,
+                plate.range,
+                plate.confidence,
+                plate.cameraName,
+                plate.captureTimeNanos);
+    }
+
+    public static VidarSpatialPoint fromTrack(VidarSpatialTrack track) {
+        if (track == null) {
+            return null;
+        }
+        Kind kind;
+        switch (track.kind) {
+            case FOE:
+                kind = Kind.FOE;
+                break;
+            case ALLY:
+                kind = Kind.ALLY;
+                break;
+            case ELEMENT:
+            default:
+                kind = Kind.ELEMENT;
+                break;
+        }
+        return new VidarSpatialPoint(
+                kind,
+                Source.REMEMBERED,
+                track.trackId,
+                track.elementId,
+                -1,
+                track.robotX,
+                track.robotY,
+                track.velFieldXInPerSec,
+                track.velFieldYInPerSec,
+                track.range,
+                track.confidence,
+                track.cameraName,
+                track.captureTimeNanos);
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatialTrack.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatialTrack.java
@@ -1,0 +1,267 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+
+/**
+ * Persistent spatial track with field-frame velocity and predict/update helpers.
+ */
+public final class VidarSpatialTrack {
+
+    public enum MotionClass {
+        UNKNOWN,
+        STATIC,
+        MOVING
+    }
+
+    public final int trackId;
+    public final VidarWorldModel.Kind kind;
+    public final String elementId;
+    public final double robotX;
+    public final double robotY;
+    public final Double fieldXIn;
+    public final Double fieldYIn;
+    public final double velFieldXInPerSec;
+    public final double velFieldYInPerSec;
+    public final double range;
+    public final double confidence;
+    public final String cameraName;
+    public final long lastSeenNanos;
+    public final long lastUpdateNanos;
+    public final long captureTimeNanos;
+    public final int missCount;
+    public final int staticStableFrames;
+    public final MotionClass motionClass;
+
+    VidarSpatialTrack(
+            int trackId,
+            VidarWorldModel.Kind kind,
+            String elementId,
+            double robotX,
+            double robotY,
+            Double fieldXIn,
+            Double fieldYIn,
+            double velFieldXInPerSec,
+            double velFieldYInPerSec,
+            double range,
+            double confidence,
+            String cameraName,
+            long lastSeenNanos,
+            long lastUpdateNanos,
+            long captureTimeNanos,
+            int missCount,
+            int staticStableFrames,
+            MotionClass motionClass) {
+        this.trackId = trackId;
+        this.kind = kind;
+        this.elementId = elementId == null ? "" : elementId;
+        this.robotX = robotX;
+        this.robotY = robotY;
+        this.fieldXIn = fieldXIn;
+        this.fieldYIn = fieldYIn;
+        this.velFieldXInPerSec = velFieldXInPerSec;
+        this.velFieldYInPerSec = velFieldYInPerSec;
+        this.range = range;
+        this.confidence = confidence;
+        this.cameraName = cameraName == null ? "" : cameraName;
+        this.lastSeenNanos = lastSeenNanos;
+        this.lastUpdateNanos = lastUpdateNanos;
+        this.captureTimeNanos = captureTimeNanos;
+        this.missCount = missCount;
+        this.staticStableFrames = staticStableFrames;
+        this.motionClass = motionClass == null ? MotionClass.UNKNOWN : motionClass;
+    }
+
+    public double bearingDeg() {
+        return Math.toDegrees(Math.atan2(robotY, robotX));
+    }
+
+    public double distance() {
+        return Math.hypot(robotX, robotY);
+    }
+
+    public double speedFieldInPerSec() {
+        return Math.hypot(velFieldXInPerSec, velFieldYInPerSec);
+    }
+
+    /** Predict track to {@code nowNanos} and reproject into the current robot frame. */
+    VidarSpatialTrack predict(long nowNanos, Pose2D fieldPose) {
+        double dtSec = dtSeconds(lastUpdateNanos, nowNanos);
+        if (fieldXIn != null && fieldYIn != null && fieldPose != null) {
+            double predFieldX = fieldXIn;
+            double predFieldY = fieldYIn;
+            if (motionClass == MotionClass.MOVING) {
+                predFieldX = fieldXIn + velFieldXInPerSec * dtSec;
+                predFieldY = fieldYIn + velFieldYInPerSec * dtSec;
+            }
+            double[] robot = fieldToRobot(predFieldX, predFieldY, fieldPose);
+            return copyWith(robot[0], robot[1], predFieldX, predFieldY,
+                    velFieldXInPerSec, velFieldYInPerSec, confidence * 0.99,
+                    lastSeenNanos, nowNanos, missCount, staticStableFrames, motionClass);
+        }
+        return copyWith(robotX, robotY, fieldXIn, fieldYIn,
+                velFieldXInPerSec, velFieldYInPerSec, confidence * 0.99,
+                lastSeenNanos, nowNanos, missCount, staticStableFrames, motionClass);
+    }
+
+    /** Gate distance in robot frame to a detection (uses predicted robot position). */
+    double gateDistanceTo(VidarTrackDetection detection) {
+        return Math.hypot(robotX - detection.robotX, robotY - detection.robotY);
+    }
+
+    static VidarSpatialTrack birth(
+            int trackId,
+            VidarTrackDetection detection,
+            long nowNanos,
+            Pose2D fieldPose) {
+        Double fieldX = null;
+        Double fieldY = null;
+        if (fieldPose != null) {
+            fieldX = fieldPose.getX(DistanceUnit.INCH) + detection.robotX;
+            fieldY = fieldPose.getY(DistanceUnit.INCH) + detection.robotY;
+        }
+        MotionClass motion = MotionClass.UNKNOWN;
+        return new VidarSpatialTrack(
+                trackId,
+                detection.kind,
+                detection.elementId,
+                detection.robotX,
+                detection.robotY,
+                fieldX,
+                fieldY,
+                0,
+                0,
+                detection.range,
+                detection.confidence,
+                detection.cameraName,
+                nowNanos,
+                nowNanos,
+                detection.captureTimeNanos,
+                0,
+                0,
+                motion);
+    }
+
+    VidarSpatialTrack updateFromDetection(
+            VidarTrackDetection detection,
+            long nowNanos,
+            Pose2D fieldPose,
+            double dtSec) {
+        Double newFieldX = fieldXIn;
+        Double newFieldY = fieldYIn;
+        if (fieldPose != null) {
+            newFieldX = fieldPose.getX(DistanceUnit.INCH) + detection.robotX;
+            newFieldY = fieldPose.getY(DistanceUnit.INCH) + detection.robotY;
+        }
+
+        double alpha = VidarConfig.WORLD_TRACK_POS_ALPHA;
+        double mergedRobotX = alpha * detection.robotX + (1.0 - alpha) * robotX;
+        double mergedRobotY = alpha * detection.robotY + (1.0 - alpha) * robotY;
+        if (newFieldX != null && fieldXIn != null && newFieldY != null && fieldYIn != null) {
+            newFieldX = alpha * newFieldX + (1.0 - alpha) * fieldXIn;
+            newFieldY = alpha * newFieldY + (1.0 - alpha) * fieldYIn;
+        }
+
+        double newVelX = velFieldXInPerSec;
+        double newVelY = velFieldYInPerSec;
+        if (newFieldX != null && fieldXIn != null && newFieldY != null && fieldYIn != null
+                && dtSec >= VidarConfig.WORLD_TRACK_MIN_DT_SEC
+                && dtSec <= VidarConfig.WORLD_TRACK_MAX_DT_SEC) {
+            double rawVx = (newFieldX - fieldXIn) / dtSec;
+            double rawVy = (newFieldY - fieldYIn) / dtSec;
+            double jump = Math.hypot(newFieldX - fieldXIn, newFieldY - fieldYIn);
+            if (jump <= gateRadius() * 2.0) {
+                double velAlpha = VidarConfig.WORLD_TRACK_VEL_ALPHA;
+                newVelX = velAlpha * rawVx + (1.0 - velAlpha) * velFieldXInPerSec;
+                newVelY = velAlpha * rawVy + (1.0 - velAlpha) * velFieldYInPerSec;
+            }
+        }
+
+        int newStaticFrames = staticStableFrames;
+        MotionClass newMotion = motionClass;
+        if (kind == VidarWorldModel.Kind.ELEMENT) {
+            if (Math.hypot(newVelX, newVelY) < VidarConfig.WORLD_TRACK_STATIC_SPEED_IN_PER_SEC) {
+                newStaticFrames++;
+            } else {
+                newStaticFrames = 0;
+            }
+            if (newStaticFrames >= VidarConfig.WORLD_TRACK_STATIC_FRAMES) {
+                newMotion = MotionClass.STATIC;
+                newVelX = 0;
+                newVelY = 0;
+            }
+        } else if (Math.hypot(newVelX, newVelY) >= VidarConfig.WORLD_TRACK_MOVING_SPEED_IN_PER_SEC) {
+            newMotion = MotionClass.MOVING;
+        }
+
+        double mergedConf = Math.max(confidence, detection.confidence);
+        double mergedRange = Double.isNaN(detection.range) ? range : detection.range;
+        return new VidarSpatialTrack(
+                trackId, kind, elementId.isEmpty() ? detection.elementId : elementId,
+                mergedRobotX, mergedRobotY, newFieldX, newFieldY,
+                newVelX, newVelY, mergedRange, mergedConf, detection.cameraName,
+                nowNanos, nowNanos, detection.captureTimeNanos,
+                0, newStaticFrames, newMotion);
+    }
+
+    VidarSpatialTrack coast(long nowNanos, Pose2D fieldPose) {
+        VidarSpatialTrack predicted = predict(nowNanos, fieldPose);
+        return predicted.copyWith(predicted.robotX, predicted.robotY, predicted.fieldXIn, predicted.fieldYIn,
+                predicted.velFieldXInPerSec, predicted.velFieldYInPerSec,
+                predicted.confidence * 0.96, predicted.lastSeenNanos, nowNanos,
+                missCount + 1, staticStableFrames, motionClass);
+    }
+
+    double gateRadius() {
+        switch (kind) {
+            case FOE:
+            case ALLY:
+                return VidarConfig.WORLD_TRACK_GATE_RADIUS_FOE_IN;
+            case ELEMENT:
+            default:
+                return VidarConfig.WORLD_TRACK_GATE_RADIUS_IN;
+        }
+    }
+
+    private VidarSpatialTrack copyWith(
+            double newRobotX,
+            double newRobotY,
+            Double newFieldX,
+            Double newFieldY,
+            double newVelX,
+            double newVelY,
+            double newConfidence,
+            long newLastSeen,
+            long newLastUpdate,
+            int newMissCount,
+            int newStaticFrames,
+            MotionClass newMotion) {
+        return new VidarSpatialTrack(
+                trackId, kind, elementId, newRobotX, newRobotY, newFieldX, newFieldY,
+                newVelX, newVelY, range, newConfidence, cameraName,
+                newLastSeen, newLastUpdate, captureTimeNanos,
+                newMissCount, newStaticFrames, newMotion);
+    }
+
+    static double dtSeconds(long fromNanos, long toNanos) {
+        if (fromNanos <= 0 || toNanos <= fromNanos) {
+            return 0;
+        }
+        return (toNanos - fromNanos) / 1_000_000_000.0;
+    }
+
+    static double[] fieldToRobot(double fieldX, double fieldY, Pose2D robotFieldPose) {
+        double rx = robotFieldPose.getX(DistanceUnit.INCH);
+        double ry = robotFieldPose.getY(DistanceUnit.INCH);
+        double heading = Math.toRadians(robotFieldPose.getHeading(AngleUnit.DEGREES));
+        double dx = fieldX - rx;
+        double dy = fieldY - ry;
+        double cos = Math.cos(-heading);
+        double sin = Math.sin(-heading);
+        return new double[] {
+                dx * cos - dy * sin,
+                dx * sin + dy * cos
+        };
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatialTrack.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatialTrack.java
@@ -1,7 +1,5 @@
 package org.firstinspires.ftc.teamcode.vidar;
 
-import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
-import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
 
 /**
@@ -95,14 +93,14 @@ public final class VidarSpatialTrack {
                 predFieldX = fieldXIn + velFieldXInPerSec * dtSec;
                 predFieldY = fieldYIn + velFieldYInPerSec * dtSec;
             }
-            double[] robot = fieldToRobot(predFieldX, predFieldY, fieldPose);
+            double[] robot = VidarCoordinateFrames.fieldToRobot(predFieldX, predFieldY, fieldPose);
             return copyWith(robot[0], robot[1], predFieldX, predFieldY,
                     velFieldXInPerSec, velFieldYInPerSec, confidence * 0.99,
-                    lastSeenNanos, nowNanos, missCount, staticStableFrames, motionClass);
+                    lastSeenNanos, lastUpdateNanos, missCount, staticStableFrames, motionClass);
         }
         return copyWith(robotX, robotY, fieldXIn, fieldYIn,
                 velFieldXInPerSec, velFieldYInPerSec, confidence * 0.99,
-                lastSeenNanos, nowNanos, missCount, staticStableFrames, motionClass);
+                lastSeenNanos, lastUpdateNanos, missCount, staticStableFrames, motionClass);
     }
 
     /** Gate distance in robot frame to a detection (uses predicted robot position). */
@@ -118,8 +116,12 @@ public final class VidarSpatialTrack {
         Double fieldX = null;
         Double fieldY = null;
         if (fieldPose != null) {
-            fieldX = fieldPose.getX(DistanceUnit.INCH) + detection.robotX;
-            fieldY = fieldPose.getY(DistanceUnit.INCH) + detection.robotY;
+            double[] field = VidarCoordinateFrames.robotToField(
+                    detection.robotX, detection.robotY, fieldPose);
+            if (!Double.isNaN(field[0]) && !Double.isNaN(field[1])) {
+                fieldX = field[0];
+                fieldY = field[1];
+            }
         }
         MotionClass motion = MotionClass.UNKNOWN;
         return new VidarSpatialTrack(
@@ -151,8 +153,12 @@ public final class VidarSpatialTrack {
         Double newFieldX = fieldXIn;
         Double newFieldY = fieldYIn;
         if (fieldPose != null) {
-            newFieldX = fieldPose.getX(DistanceUnit.INCH) + detection.robotX;
-            newFieldY = fieldPose.getY(DistanceUnit.INCH) + detection.robotY;
+            double[] field = VidarCoordinateFrames.robotToField(
+                    detection.robotX, detection.robotY, fieldPose);
+            if (!Double.isNaN(field[0]) && !Double.isNaN(field[1])) {
+                newFieldX = field[0];
+                newFieldY = field[1];
+            }
         }
 
         double alpha = VidarConfig.WORLD_TRACK_POS_ALPHA;
@@ -209,7 +215,7 @@ public final class VidarSpatialTrack {
         VidarSpatialTrack predicted = predict(nowNanos, fieldPose);
         return predicted.copyWith(predicted.robotX, predicted.robotY, predicted.fieldXIn, predicted.fieldYIn,
                 predicted.velFieldXInPerSec, predicted.velFieldYInPerSec,
-                predicted.confidence * 0.96, predicted.lastSeenNanos, nowNanos,
+                predicted.confidence * 0.96, predicted.lastSeenNanos, predicted.lastUpdateNanos,
                 missCount + 1, staticStableFrames, motionClass);
     }
 
@@ -249,19 +255,5 @@ public final class VidarSpatialTrack {
             return 0;
         }
         return (toNanos - fromNanos) / 1_000_000_000.0;
-    }
-
-    static double[] fieldToRobot(double fieldX, double fieldY, Pose2D robotFieldPose) {
-        double rx = robotFieldPose.getX(DistanceUnit.INCH);
-        double ry = robotFieldPose.getY(DistanceUnit.INCH);
-        double heading = Math.toRadians(robotFieldPose.getHeading(AngleUnit.DEGREES));
-        double dx = fieldX - rx;
-        double dy = fieldY - ry;
-        double cos = Math.cos(-heading);
-        double sin = Math.sin(-heading);
-        return new double[] {
-                dx * cos - dy * sin,
-                dx * sin + dy * cos
-        };
     }
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTagScoutRunner.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTagScoutRunner.java
@@ -1,153 +1,160 @@
-package org.firstinspires.ftc.teamcode.vidar;
-
-import org.opencv.core.Mat;
-import org.opencv.core.MatOfPoint;
-import org.opencv.core.MatOfPoint2f;
-import org.opencv.core.Rect;
-import org.opencv.core.Size;
-import org.opencv.imgproc.Imgproc;
-
-import java.util.List;
-
-/**
- * Reusable-buffer tag scout — edge/contour pass without per-frame Mat churn.
- */
-public final class VidarTagScoutRunner {
-
-    private final VidarContourWorkspacePool workspacePool = new VidarContourWorkspacePool();
-
-    private Mat reusableScout;
-    private Mat reusableGray;
-    private Mat reusableEdges;
-    private Mat reusableHierarchy;
-
-    public VidarTagScoutResult run(Mat frameBgra) {
-        if (frameBgra == null || frameBgra.empty()) {
-            return null;
-        }
-
-        VidarContourWorkspace workspace = workspacePool.borrow();
-        try {
-            int cols = frameBgra.cols();
-            int rows = frameBgra.rows();
-            Rect top = VidarFrameRegions.tagTopHalf(cols, rows);
-
-            Mat topRoi = null;
-            try {
-                topRoi = new Mat(frameBgra, top);
-                int scoutW = VidarTagConfig.SCOUT_WIDTH;
-                int scoutH = Math.max(8, top.height * scoutW / Math.max(1, top.width));
-                reusableScout = ensureRgba(reusableScout, scoutH, scoutW);
-                Imgproc.resize(topRoi, reusableScout, new Size(scoutW, scoutH), 0, 0, Imgproc.INTER_AREA);
-
-                reusableGray = ensureGray(reusableGray, scoutH, scoutW);
-                Imgproc.cvtColor(reusableScout, reusableGray, Imgproc.COLOR_RGBA2GRAY);
-                Imgproc.GaussianBlur(reusableGray, reusableGray, new Size(3, 3), 0);
-
-                reusableEdges = ensureGray(reusableEdges, scoutH, scoutW);
-                Imgproc.Canny(reusableGray, reusableEdges, 60, 160);
-
-                if (reusableHierarchy == null) {
-                    reusableHierarchy = new Mat();
-                }
-
-                workspace.releaseContours();
-                List<MatOfPoint> contours = workspace.contours;
-                Imgproc.findContours(
-                        reusableEdges,
-                        contours,
-                        reusableHierarchy,
-                        Imgproc.RETR_EXTERNAL,
-                        Imgproc.CHAIN_APPROX_SIMPLE);
-
-                MatOfPoint2f curve = workspace.curve;
-                MatOfPoint2f approx = workspace.approx;
-
-                VidarTagScoutResult best = null;
-                double bestScore = -1;
-
-                for (MatOfPoint contour : contours) {
-                    double area = Imgproc.contourArea(contour);
-                    if (area < 40) {
-                        contour.release();
-                        continue;
-                    }
-
-                    contour.convertTo(curve, org.opencv.core.CvType.CV_32FC2);
-                    double peri = Imgproc.arcLength(curve, true);
-                    Imgproc.approxPolyDP(curve, approx, 0.06 * peri, true);
-
-                    if (approx.total() < 4 || approx.total() > 6) {
-                        contour.release();
-                        continue;
-                    }
-
-                    Rect box = Imgproc.boundingRect(contour);
-                    double aspect = Math.max(box.width, box.height)
-                            / Math.max(1.0, Math.min(box.width, box.height));
-                    if (aspect > 1.6) {
-                        contour.release();
-                        continue;
-                    }
-
-                    double cxScout = box.x + box.width / 2.0;
-                    double cyScout = box.y + box.height / 2.0;
-                    double wScout = Math.max(box.width, box.height);
-
-                    double cxFull = top.x + cxScout * top.width / scoutW;
-                    double cyFull = top.y + cyScout * top.height / scoutH;
-                    double wFull = wScout * top.width / scoutW;
-
-                    if (wFull < VidarTagConfig.SCOUT_MIN_WIDTH_PX) {
-                        contour.release();
-                        continue;
-                    }
-
-                    VidarFrameRegions.HorizontalBand band = VidarFrameRegions.bandForCx(cxFull, cols);
-                    double score = area * (1.0 / aspect);
-                    if (score > bestScore) {
-                        bestScore = score;
-                        best = new VidarTagScoutResult(cxFull, cyFull, wFull, band);
-                    }
-                    contour.release();
-                }
-                return best;
-            } finally {
-                if (topRoi != null) {
-                    topRoi.release();
-                }
-            }
-        } finally {
-            workspacePool.release(workspace);
-        }
-    }
-
-    public void release() {
-        if (reusableScout != null) reusableScout.release();
-        if (reusableGray != null) reusableGray.release();
-        if (reusableEdges != null) reusableEdges.release();
-        if (reusableHierarchy != null) reusableHierarchy.release();
-        reusableScout = reusableGray = reusableEdges = reusableHierarchy = null;
-    }
-
-    private static Mat ensureRgba(Mat mat, int rows, int cols) {
-        if (mat == null || mat.empty() || mat.rows() != rows || mat.cols() != cols) {
-            if (mat != null) {
-                mat.release();
-            }
-            return new Mat(rows, cols, org.opencv.core.CvType.CV_8UC4);
-        }
-        return mat;
-    }
-
-    private static Mat ensureGray(Mat mat, int rows, int cols) {
-        if (mat == null || mat.empty() || mat.rows() != rows || mat.cols() != cols) {
-            if (mat != null) {
-                mat.release();
-            }
-            return new Mat(rows, cols, org.opencv.core.CvType.CV_8UC1);
-        }
-        return mat;
-    }
-}
-
+package org.firstinspires.ftc.teamcode.vidar;
+
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.MatOfPoint2f;
+import org.opencv.core.Rect;
+import org.opencv.core.Size;
+import org.opencv.imgproc.Imgproc;
+
+import java.util.List;
+
+/**
+ * Reusable-buffer tag scout — edge/contour pass without per-frame Mat churn.
+ */
+public final class VidarTagScoutRunner {
+
+    private final VidarContourWorkspacePool workspacePool = new VidarContourWorkspacePool();
+
+    private Mat reusableScout;
+    private Mat reusableGray;
+    private Mat reusableEdges;
+    private Mat reusableHierarchy;
+
+    public VidarTagScoutResult run(Mat frameBgra) {
+        return run(frameBgra, null);
+    }
+
+    public VidarTagScoutResult run(Mat frameBgra, VidarCameraProfile profile) {
+        if (frameBgra == null || frameBgra.empty()) {
+            return null;
+        }
+
+        VidarContourWorkspace workspace = workspacePool.borrow();
+        try {
+            int cols = frameBgra.cols();
+            int rows = frameBgra.rows();
+            VidarRoiRect tag = profile == null
+                    ? VidarCameraRoiConfig.DEFAULT.tagRoi(cols, rows).clamped(cols, rows)
+                    : VidarFrameRegions.tagRoi(profile, cols, rows);
+            Rect tagRegion = new Rect(tag.x, tag.y, tag.width, tag.height);
+
+            Mat topRoi = null;
+            try {
+                topRoi = new Mat(frameBgra, tagRegion);
+                int scoutW = VidarTagConfig.SCOUT_WIDTH;
+                int scoutH = Math.max(8, tagRegion.height * scoutW / Math.max(1, tagRegion.width));
+                reusableScout = ensureRgba(reusableScout, scoutH, scoutW);
+                Imgproc.resize(topRoi, reusableScout, new Size(scoutW, scoutH), 0, 0, Imgproc.INTER_AREA);
+
+                reusableGray = ensureGray(reusableGray, scoutH, scoutW);
+                Imgproc.cvtColor(reusableScout, reusableGray, Imgproc.COLOR_RGBA2GRAY);
+                Imgproc.GaussianBlur(reusableGray, reusableGray, new Size(3, 3), 0);
+
+                reusableEdges = ensureGray(reusableEdges, scoutH, scoutW);
+                Imgproc.Canny(reusableGray, reusableEdges, 60, 160);
+
+                if (reusableHierarchy == null) {
+                    reusableHierarchy = new Mat();
+                }
+
+                workspace.releaseContours();
+                List<MatOfPoint> contours = workspace.contours;
+                Imgproc.findContours(
+                        reusableEdges,
+                        contours,
+                        reusableHierarchy,
+                        Imgproc.RETR_EXTERNAL,
+                        Imgproc.CHAIN_APPROX_SIMPLE);
+
+                MatOfPoint2f curve = workspace.curve;
+                MatOfPoint2f approx = workspace.approx;
+
+                VidarTagScoutResult best = null;
+                double bestScore = -1;
+
+                for (MatOfPoint contour : contours) {
+                    double area = Imgproc.contourArea(contour);
+                    if (area < 40) {
+                        contour.release();
+                        continue;
+                    }
+
+                    contour.convertTo(curve, org.opencv.core.CvType.CV_32FC2);
+                    double peri = Imgproc.arcLength(curve, true);
+                    Imgproc.approxPolyDP(curve, approx, 0.06 * peri, true);
+
+                    if (approx.total() < 4 || approx.total() > 6) {
+                        contour.release();
+                        continue;
+                    }
+
+                    Rect box = Imgproc.boundingRect(contour);
+                    double aspect = Math.max(box.width, box.height)
+                            / Math.max(1.0, Math.min(box.width, box.height));
+                    if (aspect > 1.6) {
+                        contour.release();
+                        continue;
+                    }
+
+                    double cxScout = box.x + box.width / 2.0;
+                    double cyScout = box.y + box.height / 2.0;
+                    double wScout = Math.max(box.width, box.height);
+
+                    double cxFull = tagRegion.x + cxScout * tagRegion.width / scoutW;
+                    double cyFull = tagRegion.y + cyScout * tagRegion.height / scoutH;
+                    double wFull = wScout * tagRegion.width / scoutW;
+
+                    if (wFull < VidarTagConfig.SCOUT_MIN_WIDTH_PX) {
+                        contour.release();
+                        continue;
+                    }
+
+                    VidarFrameRegions.HorizontalBand band = VidarFrameRegions.bandForCx(cxFull, cols);
+                    double score = area * (1.0 / aspect);
+                    if (score > bestScore) {
+                        bestScore = score;
+                        best = new VidarTagScoutResult(cxFull, cyFull, wFull, band);
+                    }
+                    contour.release();
+                }
+                return best;
+            } finally {
+                if (topRoi != null) {
+                    topRoi.release();
+                }
+            }
+        } finally {
+            workspacePool.release(workspace);
+        }
+    }
+
+    public void release() {
+        if (reusableScout != null) reusableScout.release();
+        if (reusableGray != null) reusableGray.release();
+        if (reusableEdges != null) reusableEdges.release();
+        if (reusableHierarchy != null) reusableHierarchy.release();
+        reusableScout = reusableGray = reusableEdges = reusableHierarchy = null;
+    }
+
+    private static Mat ensureRgba(Mat mat, int rows, int cols) {
+        if (mat == null || mat.empty() || mat.rows() != rows || mat.cols() != cols) {
+            if (mat != null) {
+                mat.release();
+            }
+            return new Mat(rows, cols, org.opencv.core.CvType.CV_8UC4);
+        }
+        return mat;
+    }
+
+    private static Mat ensureGray(Mat mat, int rows, int cols) {
+        if (mat == null || mat.empty() || mat.rows() != rows || mat.cols() != cols) {
+            if (mat != null) {
+                mat.release();
+            }
+            return new Mat(rows, cols, org.opencv.core.CvType.CV_8UC1);
+        }
+        return mat;
+    }
+}
+

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTeleOp.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTeleOp.java
@@ -2,35 +2,33 @@ package org.firstinspires.ftc.teamcode.vidar;
 
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.hardware.DcMotor;
-import com.qualcomm.robotcore.hardware.DcMotorSimple;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+
+import java.util.List;
 
 /**
- * Lesson 2 — drive with gamepad; nudge away from foe plates using world memory.
+ * Lesson 2 — spatial snapshot telemetry (no motor output).
+ *
+ * <p>ViDAR reports pose and the three spatial groups: elements, allies, foes.
  *
  * <p>INIT: Y=RED, B=BLUE on gamepad1 (or color sensor on own sign).
  */
-@TeleOp(name = "ViDAR: TeleOp", group = "ViDAR")
+@TeleOp(name = "ViDAR: Spatial", group = "ViDAR")
 public class VidarTeleOp extends LinearOpMode {
 
-    private DcMotor leftDrive;
-    private DcMotor rightDrive;
-    private VidarMultiVision vision;
-    private VidarWorldModel world;
+    private VidarSpatial spatial;
     private VidarAllianceSelector alliance;
 
     @Override
     public void runOpMode() {
-        leftDrive = hardwareMap.get(DcMotor.class, VidarConfig.LEFT_DRIVE);
-        rightDrive = hardwareMap.get(DcMotor.class, VidarConfig.RIGHT_DRIVE);
-        leftDrive.setDirection(DcMotorSimple.Direction.FORWARD);
-        rightDrive.setDirection(DcMotorSimple.Direction.REVERSE);
-
         alliance = new VidarAllianceSelector(hardwareMap);
-        vision = new VidarMultiVision(hardwareMap, null, alliance::get);
-        world = new VidarWorldModel();
+        spatial = VidarSpatial.create(hardwareMap, null, alliance::get);
 
-        telemetry.addLine("ViDAR TeleOp — INIT: Y=RED B=BLUE");
+        telemetry.addLine("ViDAR Spatial — elements / allies / foes (no motors)");
+        telemetry.addLine("Motion tracks: off (no odom supplier)");
         telemetry.update();
 
         while (!isStarted() && !isStopRequested()) {
@@ -43,47 +41,31 @@ public class VidarTeleOp extends LinearOpMode {
 
         while (opModeIsActive()) {
             alliance.pollRuntime(gamepad1);
+            spatial.update();
 
-            long now = System.nanoTime();
-            vision.update();
-            world.update(vision, now);
+            List<VidarSpatialPoint> elements = spatial.elements();
+            List<VidarSpatialPoint> allies = spatial.allies();
+            List<VidarSpatialPoint> foes = spatial.foes();
+            Pose2D field = spatial.fieldPose();
 
-            double drive = -gamepad1.left_stick_y * VidarConfig.DRIVE_SPEED;
-            double turn = gamepad1.right_stick_x * VidarConfig.DRIVE_SPEED;
-
-            turn += avoidanceTurn(vision.getBestFoe());
-
-            leftDrive.setPower(drive + turn);
-            rightDrive.setPower(drive - turn);
-
-            VidarAlliance ours = alliance.get();
             telemetry.addData("Alliance", alliance.formatStatus());
-            telemetry.addData("Element", VidarBlobUtil.formatElement(vision.getBestElement()));
-            telemetry.addData("Foe", VidarBlobUtil.formatPlate(vision.getBestFoe(), ours));
-            telemetry.addData("World foes", world.getTracks(VidarWorldModel.Kind.FOE).size());
-            telemetry.addData("Drive", "%.2f  Turn: %.2f", drive, turn);
+            telemetry.addData("Motion tracks", spatial.isMotionTrackingActive());
+            telemetry.addData("Field pose", field == null ? "—"
+                    : String.format("(%.1f, %.1f) %.0f°",
+                    field.getX(DistanceUnit.INCH),
+                    field.getY(DistanceUnit.INCH),
+                    field.getHeading(AngleUnit.DEGREES)));
+            telemetry.addData("Elements", elements.size());
+            telemetry.addData("Nearest element", VidarBlobUtil.formatSpatialPoint(
+                    elements.isEmpty() ? null : elements.get(0)));
+            telemetry.addData("Nearest ally", VidarBlobUtil.formatSpatialPoint(
+                    allies.isEmpty() ? null : allies.get(0)));
+            telemetry.addData("Nearest foe", VidarBlobUtil.formatSpatialPoint(
+                    foes.isEmpty() ? null : foes.get(0)));
+            telemetry.addData("Intake blocked", spatial.intakeBlocked());
             telemetry.update();
         }
 
-        leftDrive.setPower(0);
-        rightDrive.setPower(0);
-        vision.close();
-    }
-
-    private double avoidanceTurn(VidarPlateObservation foe) {
-        if (foe == null) {
-            return 0;
-        }
-
-        double frameWidth = VidarConfig.portalCameraResolution().getWidth();
-        double error = VidarBlobUtil.errorFromCenter(foe, frameWidth);
-        double dist = Math.abs(error);
-        if (dist > VidarConfig.AVOID_CENTER_RADIUS) {
-            return 0;
-        }
-
-        double direction = error > 0 ? -1 : 1;
-        double strength = 1.0 - (dist / VidarConfig.AVOID_CENTER_RADIUS);
-        return direction * VidarConfig.AVOID_TURN_POWER * strength;
+        spatial.close();
     }
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTrackAssociator.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTrackAssociator.java
@@ -77,10 +77,11 @@ final class VidarTrackAssociator {
             if (trackUsed[match.trackIndex] || detUsed[match.detectionIndex]) {
                 continue;
             }
-            VidarSpatialTrack track = predicted.get(match.trackIndex);
+            VidarSpatialTrack predictedTrack = predicted.get(match.trackIndex);
+            VidarSpatialTrack sourceTrack = tracks.get(match.trackIndex);
             VidarTrackDetection det = detections.get(match.detectionIndex);
-            double dtSec = VidarSpatialTrack.dtSeconds(track.lastUpdateNanos, nowNanos);
-            updated.add(track.updateFromDetection(det, nowNanos, fieldPose, dtSec));
+            double dtSec = VidarSpatialTrack.dtSeconds(sourceTrack.lastUpdateNanos, nowNanos);
+            updated.add(predictedTrack.updateFromDetection(det, nowNanos, fieldPose, dtSec));
             trackUsed[match.trackIndex] = true;
             detUsed[match.detectionIndex] = true;
         }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTrackAssociator.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTrackAssociator.java
@@ -1,0 +1,160 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Predict → gate → assign association for {@link VidarSpatialTrack} lists.
+ */
+final class VidarTrackAssociator {
+
+    private VidarTrackAssociator() {}
+
+    static final class Match {
+        final int trackIndex;
+        final int detectionIndex;
+        final double distance;
+
+        Match(int trackIndex, int detectionIndex, double distance) {
+            this.trackIndex = trackIndex;
+            this.detectionIndex = detectionIndex;
+            this.distance = distance;
+        }
+    }
+
+    static List<VidarSpatialTrack> associate(
+            List<VidarSpatialTrack> tracks,
+            List<VidarTrackDetection> detections,
+            Pose2D fieldPose,
+            long nowNanos,
+            int[] nextTrackIdHolder) {
+        if (tracks.isEmpty() && detections.isEmpty()) {
+            return tracks;
+        }
+
+        List<VidarSpatialTrack> predicted = new ArrayList<>(tracks.size());
+        for (VidarSpatialTrack track : tracks) {
+            predicted.add(track.predict(nowNanos, fieldPose));
+        }
+
+        if (detections.isEmpty()) {
+            List<VidarSpatialTrack> coasted = new ArrayList<>();
+            for (VidarSpatialTrack track : predicted) {
+                coasted.add(track.coast(nowNanos, fieldPose));
+            }
+            return prune(coasted, nowNanos);
+        }
+
+        List<Match> candidates = new ArrayList<>();
+        for (int ti = 0; ti < predicted.size(); ti++) {
+            VidarSpatialTrack track = predicted.get(ti);
+            for (int di = 0; di < detections.size(); di++) {
+                VidarTrackDetection det = detections.get(di);
+                if (!kindsMatch(track, det)) {
+                    continue;
+                }
+                if (!elementIdsCompatible(track.elementId, det.elementId)) {
+                    continue;
+                }
+                double dist = track.gateDistanceTo(det);
+                if (dist <= track.gateRadius()) {
+                    candidates.add(new Match(ti, di, dist));
+                }
+            }
+        }
+
+        Collections.sort(candidates, Comparator.comparingDouble(m -> m.distance));
+
+        boolean[] trackUsed = new boolean[predicted.size()];
+        boolean[] detUsed = new boolean[detections.size()];
+        List<VidarSpatialTrack> updated = new ArrayList<>();
+
+        for (Match match : candidates) {
+            if (trackUsed[match.trackIndex] || detUsed[match.detectionIndex]) {
+                continue;
+            }
+            VidarSpatialTrack track = predicted.get(match.trackIndex);
+            VidarTrackDetection det = detections.get(match.detectionIndex);
+            double dtSec = VidarSpatialTrack.dtSeconds(track.lastUpdateNanos, nowNanos);
+            updated.add(track.updateFromDetection(det, nowNanos, fieldPose, dtSec));
+            trackUsed[match.trackIndex] = true;
+            detUsed[match.detectionIndex] = true;
+        }
+
+        for (int ti = 0; ti < predicted.size(); ti++) {
+            if (trackUsed[ti]) {
+                continue;
+            }
+            updated.add(predicted.get(ti).coast(nowNanos, fieldPose));
+        }
+
+        for (int di = 0; di < detections.size(); di++) {
+            if (detUsed[di]) {
+                continue;
+            }
+            VidarTrackDetection det = detections.get(di);
+            if (det.confidence < minConfidence(det.kind)) {
+                continue;
+            }
+            updated.add(VidarSpatialTrack.birth(nextTrackIdHolder[0]++, det, nowNanos, fieldPose));
+        }
+
+        return prune(updated, nowNanos);
+    }
+
+    private static boolean kindsMatch(VidarSpatialTrack track, VidarTrackDetection det) {
+        return track.kind == det.kind;
+    }
+
+    private static boolean elementIdsCompatible(String trackId, String detId) {
+        if (trackId.isEmpty() || detId.isEmpty()) {
+            return true;
+        }
+        return trackId.equals(detId);
+    }
+
+    private static double minConfidence(VidarWorldModel.Kind kind) {
+        switch (kind) {
+            case FOE:
+            case ALLY:
+                return VidarConfig.MIN_PLATE_CONFIDENCE;
+            case ELEMENT:
+            default:
+                return VidarConfig.MIN_ELEMENT_CONFIDENCE;
+        }
+    }
+
+    private static List<VidarSpatialTrack> prune(List<VidarSpatialTrack> tracks, long nowNanos) {
+        List<VidarSpatialTrack> out = new ArrayList<>();
+        for (VidarSpatialTrack track : tracks) {
+            if (track.missCount > VidarConfig.WORLD_TRACK_MAX_MISS_FRAMES) {
+                continue;
+            }
+            double ageSec = VidarSpatialTrack.dtSeconds(track.lastSeenNanos, nowNanos);
+            if (track.missCount > 0 && ageSec > ttlSeconds(track.kind)) {
+                continue;
+            }
+            if (track.confidence < 0.05) {
+                continue;
+            }
+            out.add(track);
+        }
+        return out;
+    }
+
+    private static double ttlSeconds(VidarWorldModel.Kind kind) {
+        switch (kind) {
+            case ELEMENT:
+                return VidarConfig.WORLD_ELEMENT_TTL_SEC;
+            case FOE:
+                return VidarConfig.WORLD_FOE_TTL_SEC;
+            case ALLY:
+            default:
+                return VidarConfig.WORLD_ALLY_TTL_SEC;
+        }
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTrackDetection.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarTrackDetection.java
@@ -1,0 +1,94 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+/**
+ * Normalized spatial detection for one vision cycle — input to {@link VidarTrackAssociator}.
+ */
+public final class VidarTrackDetection {
+
+    public final VidarWorldModel.Kind kind;
+    public final String elementId;
+    public final int occurrenceRank;
+    public final double robotX;
+    public final double robotY;
+    public final double range;
+    public final double confidence;
+    public final String cameraName;
+    public final long captureTimeNanos;
+
+    public VidarTrackDetection(
+            VidarWorldModel.Kind kind,
+            String elementId,
+            int occurrenceRank,
+            double robotX,
+            double robotY,
+            double range,
+            double confidence,
+            String cameraName,
+            long captureTimeNanos) {
+        this.kind = kind;
+        this.elementId = elementId == null ? "" : elementId;
+        this.occurrenceRank = occurrenceRank;
+        this.robotX = robotX;
+        this.robotY = robotY;
+        this.range = range;
+        this.confidence = confidence;
+        this.cameraName = cameraName == null ? "" : cameraName;
+        this.captureTimeNanos = captureTimeNanos;
+    }
+
+    public static VidarTrackDetection fromElement(VidarElementObservation obs) {
+        return fromElement(obs, obs == null ? "" : obs.elementId, -1);
+    }
+
+    public static VidarTrackDetection fromElement(
+            VidarElementObservation obs, String elementId, int occurrenceRank) {
+        if (obs == null || Double.isNaN(obs.robotX) || Double.isNaN(obs.robotY)) {
+            return null;
+        }
+        String id = elementId == null || elementId.isEmpty() ? obs.elementId : elementId;
+        return new VidarTrackDetection(
+                VidarWorldModel.Kind.ELEMENT,
+                id,
+                occurrenceRank,
+                obs.robotX,
+                obs.robotY,
+                obs.range,
+                obs.confidence,
+                obs.cameraName,
+                obs.captureTimeNanos);
+    }
+
+    public static VidarTrackDetection fromPlate(
+            VidarPlateObservation plate, VidarWorldModel.Kind kind) {
+        if (plate == null || Double.isNaN(plate.robotX) || Double.isNaN(plate.robotY)) {
+            return null;
+        }
+        return new VidarTrackDetection(
+                kind,
+                "",
+                -1,
+                plate.robotX,
+                plate.robotY,
+                plate.range,
+                plate.confidence,
+                plate.cameraName,
+                plate.captureTimeNanos);
+    }
+
+    public double distance() {
+        return Math.hypot(robotX, robotY);
+    }
+
+    public VidarTrackDetection withOccurrenceRank(int occurrenceRank) {
+        return new VidarTrackDetection(
+                kind,
+                elementId,
+                occurrenceRank,
+                robotX,
+                robotY,
+                range,
+                confidence,
+                cameraName,
+                captureTimeNanos);
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarWorldModel.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarWorldModel.java
@@ -1,17 +1,15 @@
 package org.firstinspires.ftc.teamcode.vidar;
 
-import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
-import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
 
 /**
- * Short-term spatial memory with motion-corrected robot-relative tracks.
- * Stores field coordinates when pose is available; otherwise applies odom delta transform.
+ * Short-term spatial memory with predict/gate/associate tracking.
+ *
+ * <p>When {@link #isMotionTrackingActive()} is false, {@link #update} is a no-op — live vision only.
  */
 public class VidarWorldModel {
 
@@ -21,60 +19,11 @@ public class VidarWorldModel {
         FOE
     }
 
-    public static final class Track {
-        public final Kind kind;
-        public final double robotX;
-        public final double robotY;
-        public final Double fieldXIn;
-        public final Double fieldYIn;
-        public final double range;
-        public final double confidence;
-        public final String cameraName;
-        public final long lastSeenNanos;
-        public final long captureTimeNanos;
-        public final Pose2D captureRobotPose;
-
-        Track(Kind kind, double robotX, double robotY, Double fieldXIn, Double fieldYIn,
-              double range, double confidence, String cameraName,
-              long lastSeenNanos, long captureTimeNanos, Pose2D captureRobotPose) {
-            this.kind = kind;
-            this.robotX = robotX;
-            this.robotY = robotY;
-            this.fieldXIn = fieldXIn;
-            this.fieldYIn = fieldYIn;
-            this.range = range;
-            this.confidence = confidence;
-            this.cameraName = cameraName;
-            this.lastSeenNanos = lastSeenNanos;
-            this.captureTimeNanos = captureTimeNanos;
-            this.captureRobotPose = captureRobotPose;
-        }
-
-        public double bearingDeg() {
-            return Math.toDegrees(Math.atan2(robotY, robotX));
-        }
-
-        public double distance() {
-            return Math.hypot(robotX, robotY);
-        }
-
-        Track withRobotPosition(double x, double y, double confidence, long nowNanos) {
-            return new Track(kind, x, y, fieldXIn, fieldYIn, range,
-                    confidence, cameraName, nowNanos, captureTimeNanos, captureRobotPose);
-        }
-
-        Track withFieldPosition(double fieldX, double fieldY, double robotX, double robotY,
-                                double confidence, long nowNanos) {
-            return new Track(kind, robotX, robotY, fieldX, fieldY, range,
-                    confidence, cameraName, nowNanos, captureTimeNanos, captureRobotPose);
-        }
-    }
-
-    private final List<Track> tracks = new ArrayList<>();
-    private Pose2D lastRobotPose;
-    private Pose2D lastFieldPose;
+    private final List<VidarSpatialTrack> tracks = new ArrayList<>();
     private final Supplier<Pose2D> odomSupplier;
-    private final Supplier<Pose2D> fieldPoseSupplier;
+    private Supplier<Pose2D> fieldPoseSupplier;
+    private boolean motionTrackingEnabled = VidarConfig.WORLD_MOTION_TRACKING_ENABLED;
+    private int nextTrackId = 1;
 
     public VidarWorldModel() {
         this(null, null);
@@ -85,152 +34,86 @@ public class VidarWorldModel {
         this.fieldPoseSupplier = fieldPoseSupplier;
     }
 
-    public void update(VidarMultiVision vision, long nowNanos) {
-        applyMotionCorrection(nowNanos);
-        decay(nowNanos);
+    public void setFieldPoseSupplier(Supplier<Pose2D> fieldPoseSupplier) {
+        this.fieldPoseSupplier = fieldPoseSupplier;
+    }
 
-        if (vision == null) {
+    public void setMotionTrackingEnabled(boolean enabled) {
+        this.motionTrackingEnabled = enabled;
+        if (!isMotionTrackingActive()) {
+            tracks.clear();
+            nextTrackId = 1;
+        }
+    }
+
+    public boolean isMotionTrackingEnabled() {
+        return motionTrackingEnabled;
+    }
+
+    public boolean isMotionTrackingActive() {
+        return motionTrackingEnabled && odomSupplier != null;
+    }
+
+    public void update(VidarMultiVision vision, long nowNanos) {
+        if (!isMotionTrackingActive() || vision == null) {
             return;
         }
 
-        VidarElementObservation element = vision.getBestElement();
-        if (element != null && element.confidence >= VidarConfig.MIN_ELEMENT_CONFIDENCE) {
-            upsert(Kind.ELEMENT, element.robotX, element.robotY, element.range,
-                    element.confidence, element.cameraName, element.captureTimeNanos, nowNanos);
+        Pose2D fieldPose = fieldPoseSupplier == null ? null : fieldPoseSupplier.get();
+        List<VidarTrackDetection> detections = collectDetections(vision);
+        List<VidarSpatialTrack> current = new ArrayList<>(tracks);
+        int[] nextId = { nextTrackId };
+        List<VidarSpatialTrack> associated = VidarTrackAssociator.associate(
+                current, detections, fieldPose, nowNanos, nextId);
+        tracks.clear();
+        tracks.addAll(associated);
+        nextTrackId = nextId[0];
+    }
+
+    private List<VidarTrackDetection> collectDetections(VidarMultiVision vision) {
+        List<VidarTrackDetection> out = new ArrayList<>();
+        List<VidarTrackDetection> elementDets = new ArrayList<>();
+
+        VidarRankedElementFrame ranked = vision.getRankedElements();
+        if (ranked != null) {
+            for (int i = 0; i < ranked.count(); i++) {
+                VidarElementObservation obs = ranked.at(i);
+                if (obs == null || obs.confidence < VidarConfig.MIN_ELEMENT_CONFIDENCE) {
+                    continue;
+                }
+                VidarTrackDetection det = VidarTrackDetection.fromElement(obs);
+                if (det != null) {
+                    elementDets.add(det);
+                }
+            }
         }
+        out.addAll(VidarElementOccurrenceRank.assignDetectionRanks(elementDets));
 
         VidarPlateObservation foe = vision.getBestFoe();
         if (foe != null && foe.confidence >= VidarConfig.MIN_PLATE_CONFIDENCE) {
-            upsert(Kind.FOE, foe.robotX, foe.robotY, foe.range,
-                    foe.confidence, foe.cameraName, foe.captureTimeNanos, nowNanos);
+            VidarTrackDetection det = VidarTrackDetection.fromPlate(foe, Kind.FOE);
+            if (det != null) {
+                out.add(det);
+            }
         }
 
         VidarPlateObservation ally = vision.getBestAlly();
         if (ally != null && ally.confidence >= VidarConfig.MIN_PLATE_CONFIDENCE) {
-            upsert(Kind.ALLY, ally.robotX, ally.robotY, ally.range,
-                    ally.confidence, ally.cameraName, ally.captureTimeNanos, nowNanos);
-        }
-    }
-
-    private void applyMotionCorrection(long nowNanos) {
-        Pose2D robotNow = odomSupplier == null ? null : odomSupplier.get();
-        Pose2D fieldNow = fieldPoseSupplier == null ? null : fieldPoseSupplier.get();
-
-        if (robotNow != null && lastRobotPose != null) {
-            VidarMotionTransform delta = VidarMotionTransform.fromOdomDelta(
-                    lastRobotPose.getX(DistanceUnit.INCH),
-                    lastRobotPose.getY(DistanceUnit.INCH),
-                    lastRobotPose.getHeading(AngleUnit.DEGREES),
-                    robotNow.getX(DistanceUnit.INCH),
-                    robotNow.getY(DistanceUnit.INCH),
-                    robotNow.getHeading(AngleUnit.DEGREES));
-
-            List<Track> updated = new ArrayList<>();
-            for (Track track : tracks) {
-                if (fieldNow != null && track.fieldXIn != null && track.fieldYIn != null) {
-                    double[] robot = fieldToRobot(track.fieldXIn, track.fieldYIn, fieldNow);
-                    updated.add(track.withRobotPosition(robot[0], robot[1],
-                            track.confidence * 0.98, nowNanos));
-                } else {
-                    double[] pt = delta.transformPoint(track.robotX, track.robotY);
-                    updated.add(track.withRobotPosition(pt[0], pt[1],
-                            track.confidence * 0.97, nowNanos));
-                }
-            }
-            tracks.clear();
-            tracks.addAll(updated);
-        }
-
-        lastRobotPose = robotNow;
-        lastFieldPose = fieldNow;
-    }
-
-    private static double[] fieldToRobot(double fieldX, double fieldY, Pose2D robotFieldPose) {
-        double rx = robotFieldPose.getX(DistanceUnit.INCH);
-        double ry = robotFieldPose.getY(DistanceUnit.INCH);
-        double heading = Math.toRadians(robotFieldPose.getHeading(AngleUnit.DEGREES));
-        double dx = fieldX - rx;
-        double dy = fieldY - ry;
-        double cos = Math.cos(-heading);
-        double sin = Math.sin(-heading);
-        return new double[] {
-                dx * cos - dy * sin,
-                dx * sin + dy * cos
-        };
-    }
-
-    private void upsert(Kind kind, double x, double y, double range,
-                        double confidence, String cameraName, long captureNanos, long nowNanos) {
-        if (Double.isNaN(x) || Double.isNaN(y)) {
-            return;
-        }
-
-        for (Track track : tracks) {
-            if (track.kind != kind) {
-                continue;
-            }
-            if (captureNanos > 0 && track.captureTimeNanos > captureNanos) {
-                return;
-            }
-            double dist = Math.hypot(track.robotX - x, track.robotY - y);
-            if (dist <= VidarConfig.WORLD_MERGE_RADIUS_IN) {
-                tracks.remove(track);
-                double mergedConf = Math.max(track.confidence, confidence);
-                double mergedX = 0.5 * (track.robotX + x);
-                double mergedY = 0.5 * (track.robotY + y);
-                double mergedRange = Double.isNaN(range) ? track.range : range;
-                Double fieldX = track.fieldXIn;
-                Double fieldY = track.fieldYIn;
-                if (lastFieldPose != null) {
-                    fieldX = lastFieldPose.getX(DistanceUnit.INCH) + mergedX;
-                    fieldY = lastFieldPose.getY(DistanceUnit.INCH) + mergedY;
-                }
-                tracks.add(new Track(kind, mergedX, mergedY, fieldX, fieldY, mergedRange,
-                        mergedConf, cameraName, nowNanos, captureNanos, lastRobotPose));
-                return;
+            VidarTrackDetection det = VidarTrackDetection.fromPlate(ally, Kind.ALLY);
+            if (det != null) {
+                out.add(det);
             }
         }
-
-        Double fieldX = null;
-        Double fieldY = null;
-        if (lastFieldPose != null) {
-            fieldX = lastFieldPose.getX(DistanceUnit.INCH) + x;
-            fieldY = lastFieldPose.getY(DistanceUnit.INCH) + y;
-        }
-        tracks.add(new Track(kind, x, y, fieldX, fieldY, range, confidence,
-                cameraName, nowNanos, captureNanos, lastRobotPose));
+        return out;
     }
 
-    public void decay(long nowNanos) {
-        Iterator<Track> it = tracks.iterator();
-        while (it.hasNext()) {
-            Track track = it.next();
-            double ageSec = (nowNanos - track.lastSeenNanos) / 1_000_000_000.0;
-            if (ageSec > ttlSeconds(track.kind)) {
-                it.remove();
-            }
-        }
-    }
-
-    private static double ttlSeconds(Kind kind) {
-        switch (kind) {
-            case ELEMENT:
-                return VidarConfig.WORLD_ELEMENT_TTL_SEC;
-            case FOE:
-                return VidarConfig.WORLD_FOE_TTL_SEC;
-            case ALLY:
-            default:
-                return VidarConfig.WORLD_ALLY_TTL_SEC;
-        }
-    }
-
-    public List<Track> getTracks() {
+    public List<VidarSpatialTrack> getTracks() {
         return new ArrayList<>(tracks);
     }
 
-    public List<Track> getTracks(Kind kind) {
-        List<Track> out = new ArrayList<>();
-        for (Track track : tracks) {
+    public List<VidarSpatialTrack> getTracks(Kind kind) {
+        List<VidarSpatialTrack> out = new ArrayList<>();
+        for (VidarSpatialTrack track : tracks) {
             if (track.kind == kind) {
                 out.add(track);
             }
@@ -238,18 +121,18 @@ public class VidarWorldModel {
         return out;
     }
 
-    public Track nearestElement() {
+    public VidarSpatialTrack nearestElement() {
         return nearest(Kind.ELEMENT);
     }
 
-    public Track nearestFoe() {
+    public VidarSpatialTrack nearestFoe() {
         return nearest(Kind.FOE);
     }
 
-    private Track nearest(Kind kind) {
-        Track best = null;
+    private VidarSpatialTrack nearest(Kind kind) {
+        VidarSpatialTrack best = null;
         double bestDist = Double.MAX_VALUE;
-        for (Track track : tracks) {
+        for (VidarSpatialTrack track : tracks) {
             if (track.kind != kind) {
                 continue;
             }
@@ -263,7 +146,7 @@ public class VidarWorldModel {
     }
 
     public boolean intakeBlocked() {
-        for (Track track : tracks) {
+        for (VidarSpatialTrack track : tracks) {
             if (track.kind != Kind.FOE) {
                 continue;
             }


### PR DESCRIPTION
## Summary

Spatial-only facade and motion tracking — stacks on [#5](https://github.com/The-Allsparks/ViDAR/pull/5).

- `VidarSpatial` with `elements()` / `allies()` / `foes()` — no motor commands
- Predict → gate → associate tracks (`VidarTrackAssociator`), `elementId` + occurrence ranks
- Offensive lane helper, profile-aware tag scout ROI
- Browser sim parity (tracks, elementId, lane analysis)
- **Fix:** field coords use `robotToField`, velocity dt from pre-predict timestamps, odom-extrapolated field pose for tracks

## Test plan

- [ ] Run **ViDAR: Spatial Map** with odom — `Motion tracks: true`, stable `trackId` through brief occlusion
- [ ] Static element → field velocity ≈ 0; moving foe → non-zero velocity
- [ ] Serve sim — motion track overlay + offensive lane sidebar
- [ ] Log results in `docs/validation-log.md` §7

## Depends on

[#5 Coordinate frames and camera calibration foundation](https://github.com/The-Allsparks/ViDAR/pull/5) — merge first.
