### PR TITLE
refactor(java): bundled config JSON assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,12 @@ python -m pytest tests/ -v
 ### 2. Install on the Control Hub
 
 1. Clone the [FTC SDK](https://github.com/FIRST-Tech-Challenge/FtcRobotController) and open it in Android Studio.
-2. Copy `teamcode/org/firstinspires/ftc/teamcode/vidar/` → `TeamCode/src/main/java/.../vidar/`.
-3. Copy a robot template from [`config/robots/`](config/robots/README.md) to `TeamCode/src/main/assets/vidar/robot.json`.
-4. Configure USB webcams as **`Webcam 1`** … **`Webcam 4`** (see `VidarConfig.CAMERA_NAMES`).
-5. Set `VidarConfig.CAMERA_COUNT` (1–4). Alliance is set at runtime — see below.
-6. Run **ViDAR: Discover** → **ViDAR: Spatial** → **ViDAR: Spatial Map**.
+2. Copy the entire `teamcode/org/firstinspires/ftc/teamcode/vidar/` tree (including subpackages) → `TeamCode/src/main/java/.../vidar/`. See [docs/JAVA_PACKAGE_MAP.md](docs/JAVA_PACKAGE_MAP.md).
+3. Copy `teamcode/assets/vidar/` → `TeamCode/src/main/assets/vidar/` (includes `default-season.json` / `default-robot.json` fallbacks plus your `season.json` / `robot.json` overrides).
+4. Copy a robot template from [`config/robots/`](config/robots/README.md) to `TeamCode/src/main/assets/vidar/robot.json` (or edit the bundled default).
+5. Configure USB webcams as **`Webcam 1`** … **`Webcam 4`** (see `VidarConfig.CAMERA_NAMES`).
+6. Set `VidarConfig.CAMERA_COUNT` (1–4). Alliance is set at runtime — see below.
+7. Run **ViDAR: Discover** → **ViDAR: Spatial** → **ViDAR: Spatial Map**.
 
 ViDAR is a **spatial system only** — pose plus three groups (`elements()`, `allies()`, `foes()`). It never commands motors.
 

--- a/scripts/generate_default_config_assets.py
+++ b/scripts/generate_default_config_assets.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Generate bundled default-season.json and default-robot.json from VidarConfig constants."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_JAVA = ROOT / "teamcode/org/firstinspires/ftc/teamcode/vidar/VidarConfig.java"
+PROFILE_JAVA = ROOT / "teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarCameraProfile.java"
+OUT_DIR = ROOT / "teamcode/assets/vidar"
+
+
+def java_number(name: str, text: str, default: float | None = None) -> float:
+    m = re.search(
+        rf"public static final (?:int|double) {name}\s*=\s*([\d.]+)", text)
+    if m:
+        return float(m.group(1))
+    if default is not None:
+        return default
+    raise KeyError(name)
+
+
+def java_int(name: str, text: str, default: int | None = None) -> int:
+    return int(java_number(name, text, default))
+
+
+def java_double(name: str, text: str, default: float | None = None) -> float:
+    return java_number(name, text, default)
+
+
+def java_bool(name: str, text: str, default: bool = False) -> bool:
+    m = re.search(rf"public static final boolean {name}\s*=\s*(true|false)", text)
+    if m:
+        return m.group(1) == "true"
+    return default
+
+
+def java_string(name: str, text: str, default: str = "") -> str:
+    m = re.search(rf'public static final String {name}\s*=\s*"([^"]*)"', text)
+    if m:
+        return m.group(1)
+    return default
+
+
+def build_season(cfg: str) -> dict:
+    return {
+        "seasonId": "2025-decode",
+        "seasonName": "DECODE 2025 — game elements and team plates",
+        "fusion": {
+            "minElementConfidence": java_double("MIN_ELEMENT_CONFIDENCE", cfg, 0.35),
+            "minPlateConfidence": java_double("MIN_PLATE_CONFIDENCE", cfg, 0.4),
+            "maxRangeMismatchRatio": java_double("MAX_RANGE_MISMATCH_RATIO", cfg, 0.35),
+        },
+        "elements": [{
+            "id": "pollen",
+            "label": "Pollen element",
+            "diameter": java_double("DEFAULT_ELEMENT_DIAMETER", cfg, 4.9),
+            "detector": "color_blob_with_local_hough",
+            "hsv": {
+                "hMin": java_int("DEFAULT_ELEMENT_HSV_H_MIN", cfg),
+                "hMax": java_int("DEFAULT_ELEMENT_HSV_H_MAX", cfg),
+                "sMin": java_int("DEFAULT_ELEMENT_HSV_S_MIN", cfg),
+                "sMax": java_int("DEFAULT_ELEMENT_HSV_S_MAX", cfg),
+                "vMin": java_int("DEFAULT_ELEMENT_HSV_V_MIN", cfg),
+                "vMax": java_int("DEFAULT_ELEMENT_HSV_V_MAX", cfg),
+            },
+            "filters": {
+                "minAreaPx": java_int("DEFAULT_ELEMENT_MIN_AREA_PX", cfg),
+                "maxAreaPx": java_int("DEFAULT_ELEMENT_MAX_AREA_PX", cfg),
+                "minWidthPx": java_int("DEFAULT_ELEMENT_MIN_WIDTH_PX", cfg),
+                "maxWidthPx": java_int("DEFAULT_ELEMENT_MAX_WIDTH_PX", cfg),
+                "minHeightPx": java_int("DEFAULT_ELEMENT_MIN_HEIGHT_PX", cfg),
+                "maxHeightPx": java_int("DEFAULT_ELEMENT_MAX_HEIGHT_PX", cfg),
+                "maxAspectRatio": java_double("DEFAULT_ELEMENT_MAX_ASPECT_RATIO", cfg),
+                "minCircularity": java_double("DEFAULT_ELEMENT_MIN_CIRCULARITY", cfg),
+                "minFillRatio": java_double("DEFAULT_ELEMENT_MIN_FILL_RATIO", cfg),
+                "minInteriorScore": java_double("DEFAULT_ELEMENT_MIN_INTERIOR_SCORE", cfg),
+            },
+            "interior": {
+                "brightMin": java_int("DEFAULT_ELEMENT_INTERIOR_BRIGHT", cfg),
+                "spreadMax": java_int("DEFAULT_ELEMENT_INTERIOR_SPREAD", cfg),
+                "holeDarkMax": java_int("DEFAULT_ELEMENT_HOLE_DARK_MAX", cfg),
+            },
+            "morphology": {
+                "erodePasses": java_int("DEFAULT_ELEMENT_MORPH_ERODE_PASSES", cfg),
+                "dilatePasses": java_int("DEFAULT_ELEMENT_MORPH_DILATE_PASSES", cfg),
+                "openPasses": java_int("DEFAULT_ELEMENT_MORPH_OPEN_PASSES", cfg),
+                "closePasses": java_int("DEFAULT_ELEMENT_MORPH_CLOSE_PASSES", cfg),
+            },
+            "hough": {
+                "dp": java_double("HOUGH_DP", cfg),
+                "minDist": java_double("HOUGH_MIN_DIST", cfg),
+                "param1": java_double("HOUGH_PARAM1", cfg),
+                "param2": java_double("HOUGH_PARAM2", cfg),
+                "minRadius": java_int("HOUGH_MIN_RADIUS", cfg),
+                "maxRadius": java_int("HOUGH_MAX_RADIUS", cfg),
+                "minInterior": java_double("HOUGH_MIN_INTERIOR", cfg),
+                "minAreaPx": java_int("MIN_ELEMENT_AREA_PX", cfg),
+            },
+        }],
+        "plates": [
+            {
+                "alliance": "red",
+                "width": 12.0,
+                "hsv": {
+                    "hMin": java_int("PLATE_RED_H_MIN", cfg),
+                    "hMax": java_int("PLATE_RED_H_MAX", cfg),
+                    "sMin": java_int("PLATE_S_MIN", cfg),
+                    "sMax": 255,
+                    "vMin": java_int("PLATE_V_MIN", cfg),
+                    "vMax": 255,
+                },
+                "hsvWrap": {
+                    "hMin": java_int("PLATE_RED_WRAP_H_MIN", cfg),
+                    "hMax": 179,
+                    "sMin": java_int("PLATE_S_MIN", cfg),
+                    "sMax": 255,
+                    "vMin": java_int("PLATE_V_MIN", cfg),
+                    "vMax": 255,
+                },
+                "filters": {
+                    "minAreaPx": java_int("PLATE_MIN_AREA_PX", cfg),
+                    "maxAreaPx": java_int("PLATE_MAX_AREA_PX", cfg),
+                    "minAspect": java_double("PLATE_MIN_ASPECT", cfg),
+                    "maxAspect": java_double("PLATE_MAX_ASPECT", cfg),
+                    "minRectangularity": java_double("PLATE_MIN_RECTANGULARITY", cfg),
+                    "minWhiteRatio": java_double("PLATE_MIN_WHITE_RATIO", cfg),
+                },
+                "whiteDigit": {
+                    "sampleGrid": java_int("PLATE_WHITE_SAMPLE_GRID", cfg),
+                    "brightMin": java_int("PLATE_WHITE_BRIGHT_MIN", cfg),
+                    "spreadMax": java_int("PLATE_WHITE_SPREAD_MAX", cfg),
+                },
+            },
+            {
+                "alliance": "blue",
+                "width": 12.0,
+                "hsv": {
+                    "hMin": java_int("PLATE_BLUE_H_MIN", cfg),
+                    "hMax": java_int("PLATE_BLUE_H_MAX", cfg),
+                    "sMin": java_int("PLATE_S_MIN", cfg),
+                    "sMax": 255,
+                    "vMin": java_int("PLATE_V_MIN", cfg),
+                    "vMax": 255,
+                },
+                "filters": {
+                    "minAreaPx": java_int("PLATE_MIN_AREA_PX", cfg),
+                    "maxAreaPx": java_int("PLATE_MAX_AREA_PX", cfg),
+                    "minAspect": java_double("PLATE_MIN_ASPECT", cfg),
+                    "maxAspect": java_double("PLATE_MAX_ASPECT", cfg),
+                    "minRectangularity": java_double("PLATE_MIN_RECTANGULARITY", cfg),
+                    "minWhiteRatio": java_double("PLATE_MIN_WHITE_RATIO", cfg),
+                },
+                "whiteDigit": {
+                    "sampleGrid": java_int("PLATE_WHITE_SAMPLE_GRID", cfg),
+                    "brightMin": java_int("PLATE_WHITE_BRIGHT_MIN", cfg),
+                    "spreadMax": java_int("PLATE_WHITE_SPREAD_MAX", cfg),
+                },
+            },
+        ],
+    }
+
+
+def parse_four_sides(profile_text: str) -> list[dict]:
+    pattern = re.compile(
+        r'buildSide\("(\w+)"\s*,\s*([\d.]+)\s*,\s*([\d.-]+)\s*,\s*([\d.-]+)\)',
+        re.MULTILINE,
+    )
+    mounts = []
+    for m in pattern.finditer(profile_text):
+        mounts.append({
+            "name": m.group(1),
+            "bearingDeg": float(m.group(2)),
+            "mountX": float(m.group(3)),
+            "mountY": float(m.group(4)),
+        })
+    return mounts
+
+
+def build_robot(cfg: str, profile_text: str) -> dict:
+    count = java_int("CAMERA_COUNT", cfg, 1)
+    names = re.findall(r'"([^"]+)"', re.search(
+        r"CAMERA_NAMES = \{(.*?)\};", cfg, re.DOTALL).group(1))
+    sides = parse_four_sides(profile_text)
+    if not sides:
+        raise RuntimeError("Could not parse VidarCameraProfile.FOUR_SIDES")
+
+    front = sides[0]
+    camera_defaults = {
+        "horizonRowPx": 12,
+        "focalLengthPx": 340,
+        "focalLengthYPx": 340,
+        "principalPointX": 320,
+        "principalPointY": 240,
+        "calibrationWidth": 640,
+        "calibrationHeight": 480,
+        "horizontalFovDeg": 70,
+        "verticalFovDeg": 55,
+        "plateWidth": 12.0,
+        "floorLut": [
+            {"cy": 95, "dist": 12},
+            {"cy": 75, "dist": 24},
+            {"cy": 55, "dist": 36},
+            {"cy": 40, "dist": 48},
+        ],
+        "roi": {
+            "element": {"lowerFraction": 0.65, "enabled": True},
+            "plate": {"startFraction": 0.30, "bandFraction": 0.40, "enabled": True},
+            "tag": {"upperFraction": 0.65, "enabled": True},
+        },
+    }
+
+    cameras = []
+    for i in range(count):
+        side = sides[min(i, len(sides) - 1)]
+        cameras.append({
+            "index": i,
+            "webcamName": names[i] if i < len(names) else f"Webcam {i + 1}",
+            "name": side["name"],
+            "mount": {
+                "bearingDeg": side["bearingDeg"],
+                "x": side["mountX"],
+                "y": side["mountY"],
+                "z": 9.0,
+                "pitchDeg": -12,
+            },
+        })
+
+    return {
+        "robotName": "example-robot",
+        "activeCameraIndex": java_int("ACTIVE_CAMERA_INDEX", cfg, 0),
+        "cameraCount": count,
+        "dimensions": {"length": 13, "width": 13, "height": 18},
+        "alliance": {
+            "defaultAlliance": "red",
+            "colorSensorName": java_string("ALLIANCE_COLOR_SENSOR", cfg, "alliance_color"),
+            "useColorSensor": java_bool("ALLIANCE_USE_COLOR_SENSOR", cfg, True),
+            "allowRuntimeToggle": java_bool("ALLIANCE_ALLOW_RUNTIME_TOGGLE", cfg, True),
+        },
+        "cameraDefaults": camera_defaults,
+        "mountDefaults": {"yawDeg": 0, "pitchDeg": -12, "rollDeg": 0},
+        "cameras": cameras,
+    }
+
+
+def main() -> None:
+    cfg = CONFIG_JAVA.read_text(encoding="utf-8")
+    profile = PROFILE_JAVA.read_text(encoding="utf-8")
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    season_path = OUT_DIR / "default-season.json"
+    robot_path = OUT_DIR / "default-robot.json"
+    season_path.write_text(
+        json.dumps(build_season(cfg), indent=2) + "\n", encoding="utf-8")
+    robot_path.write_text(
+        json.dumps(build_robot(cfg, profile), indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {season_path}")
+    print(f"Wrote {robot_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/teamcode/assets/vidar/default-robot.json
+++ b/teamcode/assets/vidar/default-robot.json
@@ -1,0 +1,80 @@
+{
+  "robotName": "example-robot",
+  "activeCameraIndex": 0,
+  "cameraCount": 1,
+  "dimensions": {
+    "length": 13,
+    "width": 13,
+    "height": 18
+  },
+  "alliance": {
+    "defaultAlliance": "red",
+    "colorSensorName": "alliance_color",
+    "useColorSensor": true,
+    "allowRuntimeToggle": true
+  },
+  "cameraDefaults": {
+    "horizonRowPx": 12,
+    "focalLengthPx": 340,
+    "focalLengthYPx": 340,
+    "principalPointX": 320,
+    "principalPointY": 240,
+    "calibrationWidth": 640,
+    "calibrationHeight": 480,
+    "horizontalFovDeg": 70,
+    "verticalFovDeg": 55,
+    "plateWidth": 12.0,
+    "floorLut": [
+      {
+        "cy": 95,
+        "dist": 12
+      },
+      {
+        "cy": 75,
+        "dist": 24
+      },
+      {
+        "cy": 55,
+        "dist": 36
+      },
+      {
+        "cy": 40,
+        "dist": 48
+      }
+    ],
+    "roi": {
+      "element": {
+        "lowerFraction": 0.65,
+        "enabled": true
+      },
+      "plate": {
+        "startFraction": 0.3,
+        "bandFraction": 0.4,
+        "enabled": true
+      },
+      "tag": {
+        "upperFraction": 0.65,
+        "enabled": true
+      }
+    }
+  },
+  "mountDefaults": {
+    "yawDeg": 0,
+    "pitchDeg": -12,
+    "rollDeg": 0
+  },
+  "cameras": [
+    {
+      "index": 0,
+      "webcamName": "Webcam 1",
+      "name": "front",
+      "mount": {
+        "bearingDeg": 0.0,
+        "x": 6.5,
+        "y": 0.0,
+        "z": 9.0,
+        "pitchDeg": -12
+      }
+    }
+  ]
+}

--- a/teamcode/assets/vidar/default-season.json
+++ b/teamcode/assets/vidar/default-season.json
@@ -1,0 +1,118 @@
+{
+  "seasonId": "2025-decode",
+  "seasonName": "DECODE 2025 \u2014 game elements and team plates",
+  "fusion": {
+    "minElementConfidence": 0.35,
+    "minPlateConfidence": 0.35,
+    "maxRangeMismatchRatio": 0.28
+  },
+  "elements": [
+    {
+      "id": "pollen",
+      "label": "Pollen element",
+      "diameter": 5.0,
+      "detector": "color_blob_with_local_hough",
+      "hsv": {
+        "hMin": 0,
+        "hMax": 179,
+        "sMin": 0,
+        "sMax": 85,
+        "vMin": 55,
+        "vMax": 255
+      },
+      "filters": {
+        "minAreaPx": 45,
+        "maxAreaPx": 12000,
+        "minWidthPx": 8,
+        "maxWidthPx": 80,
+        "minHeightPx": 8,
+        "maxHeightPx": 80,
+        "maxAspectRatio": 2.0,
+        "minCircularity": 0.55,
+        "minFillRatio": 0.55,
+        "minInteriorScore": 0.12
+      },
+      "interior": {
+        "brightMin": 90,
+        "spreadMax": 60,
+        "holeDarkMax": 45
+      },
+      "morphology": {
+        "erodePasses": 0,
+        "dilatePasses": 0,
+        "openPasses": 1,
+        "closePasses": 2
+      },
+      "hough": {
+        "dp": 1.2,
+        "minDist": 24.0,
+        "param1": 80.0,
+        "param2": 11.0,
+        "minRadius": 8,
+        "maxRadius": 36,
+        "minInterior": 0.14,
+        "minAreaPx": 45
+      }
+    }
+  ],
+  "plates": [
+    {
+      "alliance": "red",
+      "width": 12.0,
+      "hsv": {
+        "hMin": 0,
+        "hMax": 12,
+        "sMin": 80,
+        "sMax": 255,
+        "vMin": 60,
+        "vMax": 255
+      },
+      "hsvWrap": {
+        "hMin": 168,
+        "hMax": 179,
+        "sMin": 80,
+        "sMax": 255,
+        "vMin": 60,
+        "vMax": 255
+      },
+      "filters": {
+        "minAreaPx": 120,
+        "maxAreaPx": 12000,
+        "minAspect": 1.15,
+        "maxAspect": 4.5,
+        "minRectangularity": 0.45,
+        "minWhiteRatio": 0.12
+      },
+      "whiteDigit": {
+        "sampleGrid": 5,
+        "brightMin": 175,
+        "spreadMax": 55
+      }
+    },
+    {
+      "alliance": "blue",
+      "width": 12.0,
+      "hsv": {
+        "hMin": 95,
+        "hMax": 135,
+        "sMin": 80,
+        "sMax": 255,
+        "vMin": 60,
+        "vMax": 255
+      },
+      "filters": {
+        "minAreaPx": 120,
+        "maxAreaPx": 12000,
+        "minAspect": 1.15,
+        "maxAspect": 4.5,
+        "minRectangularity": 0.45,
+        "minWhiteRatio": 0.12
+      },
+      "whiteDigit": {
+        "sampleGrid": 5,
+        "brightMin": 175,
+        "spreadMax": 55
+      }
+    }
+  ]
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/VidarTeamConfig.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/VidarTeamConfig.java
@@ -14,7 +14,9 @@ import java.io.IOException;
  *
  * <p>Copy templates from the ViDAR repo into your Android project:
  * <ul>
- *   <li>{@code config/seasons/&lt;year&gt;-&lt;game&gt;.json} (e.g. {@code 2025-decode.json}, {@code 2026-biobuzz.json}) → {@code TeamCode/src/main/assets/vidar/season.json}</li>
+ *   <li>{@code teamcode/assets/vidar/default-season.json} and {@code default-robot.json}
+ *       → bundled fallbacks (also copied with the Java tree under {@code config/bundled/})</li>
+ *   <li>{@code config/seasons/&lt;year&gt;-&lt;game&gt;.json} → {@code TeamCode/src/main/assets/vidar/season.json}</li>
  *   <li>{@code config/robots/example-robot.json} → {@code TeamCode/src/main/assets/vidar/robot.json}</li>
  * </ul>
  *

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarConfig.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarConfig.java
@@ -13,7 +13,11 @@ import android.util.Size;
  * {@link org.firstinspires.ftc.teamcode.vidar.config.VidarRobotConfig} to
  * {@link org.firstinspires.ftc.teamcode.vidar.VidarMultiVision}. See {@link org.firstinspires.ftc.teamcode.VidarTeamConfig}.
  *
- * <p>Constants below remain for backward compatibility and library defaults.
+ * <p>Season tuning (elements, plates, fusion thresholds, AprilTags) lives in bundled
+ * {@code default-season.json} / team {@code season.json}. Robot layout lives in
+ * {@code default-robot.json} / team {@code robot.json}. Constants below are
+ * <b>hardware-only fallbacks</b> (camera names, USB count, world-model radii not yet in JSON)
+ * and backward-compatible defaults when assets are missing.
  *
  * Robot config (Driver Station → Configure Robot) must include a USB webcam named
  * {@link #CAMERA_NAME} on the Control Hub.

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/config/VidarConfigLoader.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/config/VidarConfigLoader.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.vidar.config;
 
-import org.firstinspires.ftc.teamcode.vidar.VidarMultiVision;
 import org.firstinspires.ftc.teamcode.vidar.VidarAlliance;
 import org.firstinspires.ftc.teamcode.vidar.VidarElementDetectorType;
 import org.firstinspires.ftc.teamcode.vidar.VidarElementShape;
@@ -65,14 +64,34 @@ public final class VidarConfigLoader {
         }
     }
 
-    /** Built-in season matching legacy {@link VidarConfig} constants. */
+    /** Built-in season from {@code bundled/default-season.json}. */
     public static VidarSeasonConfig defaultSeason() {
-        return loadSeason(defaultSeasonJson());
+        return loadSeason(readBundledResource("default-season.json"));
     }
 
-    /** Built-in robot layout matching legacy {@link VidarConfig} + {@link VidarCameraProfile#FOUR_SIDES}. */
+    /** Built-in robot layout from {@code bundled/default-robot.json}. */
     public static VidarRobotConfig defaultRobot() {
-        return loadRobot(defaultRobotJson());
+        return loadRobot(readBundledResource("default-robot.json"));
+    }
+
+    static String readBundledResource(String resourceName) {
+        String path = "bundled/" + resourceName;
+        InputStream stream = VidarConfigLoader.class.getResourceAsStream(path);
+        if (stream == null) {
+            throw new IllegalStateException("Missing bundled config resource: " + path);
+        }
+        try (InputStream in = stream;
+             BufferedReader reader = new BufferedReader(
+                     new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append('\n');
+            }
+            return sb.toString();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to read bundled config: " + path, ex);
+        }
     }
 
     static VidarSeasonConfig parseSeason(JSONObject root) throws JSONException {
@@ -633,202 +652,5 @@ public final class VidarConfigLoader {
         }
         return VidarAlliance.RED;
     }
-
-    /** JSON string equivalent to legacy {@link VidarConfig} element/plate tuning. */
-    public static String defaultSeasonJson() {
-        return "{"
-                + "\"seasonId\":\"2025-decode\","
-                + "\"seasonName\":\"DECODE 2025 — game elements and team plates\","
-                + "\"fusion\":{"
-                + "\"minElementConfidence\":" + VidarConfig.MIN_ELEMENT_CONFIDENCE + ","
-                + "\"minPlateConfidence\":" + VidarConfig.MIN_PLATE_CONFIDENCE + ","
-                + "\"maxRangeMismatchRatio\":" + VidarConfig.MAX_RANGE_MISMATCH_RATIO
-                + "},"
-                + "\"elements\":[{"
-                + "\"id\":\"pollen\","
-                + "\"label\":\"Pollen element\","
-                + "\"diameter\":" + VidarConfig.DEFAULT_ELEMENT_DIAMETER + ","
-                + "\"detector\":\"color_blob_with_local_hough\","
-                + "\"hsv\":{"
-                + "\"hMin\":" + VidarConfig.DEFAULT_ELEMENT_HSV_H_MIN + ","
-                + "\"hMax\":" + VidarConfig.DEFAULT_ELEMENT_HSV_H_MAX + ","
-                + "\"sMin\":" + VidarConfig.DEFAULT_ELEMENT_HSV_S_MIN + ","
-                + "\"sMax\":" + VidarConfig.DEFAULT_ELEMENT_HSV_S_MAX + ","
-                + "\"vMin\":" + VidarConfig.DEFAULT_ELEMENT_HSV_V_MIN + ","
-                + "\"vMax\":" + VidarConfig.DEFAULT_ELEMENT_HSV_V_MAX
-                + "},"
-                + "\"filters\":{"
-                + "\"minAreaPx\":" + VidarConfig.DEFAULT_ELEMENT_MIN_AREA_PX + ","
-                + "\"maxAreaPx\":" + VidarConfig.DEFAULT_ELEMENT_MAX_AREA_PX + ","
-                + "\"minWidthPx\":" + VidarConfig.DEFAULT_ELEMENT_MIN_WIDTH_PX + ","
-                + "\"maxWidthPx\":" + VidarConfig.DEFAULT_ELEMENT_MAX_WIDTH_PX + ","
-                + "\"minHeightPx\":" + VidarConfig.DEFAULT_ELEMENT_MIN_HEIGHT_PX + ","
-                + "\"maxHeightPx\":" + VidarConfig.DEFAULT_ELEMENT_MAX_HEIGHT_PX + ","
-                + "\"maxAspectRatio\":" + VidarConfig.DEFAULT_ELEMENT_MAX_ASPECT_RATIO + ","
-                + "\"minCircularity\":" + VidarConfig.DEFAULT_ELEMENT_MIN_CIRCULARITY + ","
-                + "\"minFillRatio\":" + VidarConfig.DEFAULT_ELEMENT_MIN_FILL_RATIO + ","
-                + "\"minInteriorScore\":" + VidarConfig.DEFAULT_ELEMENT_MIN_INTERIOR_SCORE
-                + "},"
-                + "\"interior\":{"
-                + "\"brightMin\":" + VidarConfig.DEFAULT_ELEMENT_INTERIOR_BRIGHT + ","
-                + "\"spreadMax\":" + VidarConfig.DEFAULT_ELEMENT_INTERIOR_SPREAD + ","
-                + "\"holeDarkMax\":" + VidarConfig.DEFAULT_ELEMENT_HOLE_DARK_MAX
-                + "},"
-                + "\"morphology\":{"
-                + "\"erodePasses\":" + VidarConfig.DEFAULT_ELEMENT_MORPH_ERODE_PASSES + ","
-                + "\"dilatePasses\":" + VidarConfig.DEFAULT_ELEMENT_MORPH_DILATE_PASSES + ","
-                + "\"openPasses\":" + VidarConfig.DEFAULT_ELEMENT_MORPH_OPEN_PASSES + ","
-                + "\"closePasses\":" + VidarConfig.DEFAULT_ELEMENT_MORPH_CLOSE_PASSES
-                + "},"
-                + "\"hough\":{"
-                + "\"dp\":" + VidarConfig.HOUGH_DP + ","
-                + "\"minDist\":" + VidarConfig.HOUGH_MIN_DIST + ","
-                + "\"param1\":" + VidarConfig.HOUGH_PARAM1 + ","
-                + "\"param2\":" + VidarConfig.HOUGH_PARAM2 + ","
-                + "\"minRadius\":" + VidarConfig.HOUGH_MIN_RADIUS + ","
-                + "\"maxRadius\":" + VidarConfig.HOUGH_MAX_RADIUS + ","
-                + "\"minInterior\":" + VidarConfig.HOUGH_MIN_INTERIOR + ","
-                + "\"minAreaPx\":" + VidarConfig.MIN_ELEMENT_AREA_PX
-                + "}"
-                + "}],"
-                + "\"plates\":[{"
-                + "\"alliance\":\"red\","
-                + "\"width\":12.0,"
-                + "\"hsv\":{"
-                + "\"hMin\":" + VidarConfig.PLATE_RED_H_MIN + ","
-                + "\"hMax\":" + VidarConfig.PLATE_RED_H_MAX + ","
-                + "\"sMin\":" + VidarConfig.PLATE_S_MIN + ","
-                + "\"sMax\":255,"
-                + "\"vMin\":" + VidarConfig.PLATE_V_MIN + ","
-                + "\"vMax\":255"
-                + "},"
-                + "\"hsvWrap\":{"
-                + "\"hMin\":" + VidarConfig.PLATE_RED_WRAP_H_MIN + ","
-                + "\"hMax\":179,"
-                + "\"sMin\":" + VidarConfig.PLATE_S_MIN + ","
-                + "\"sMax\":255,"
-                + "\"vMin\":" + VidarConfig.PLATE_V_MIN + ","
-                + "\"vMax\":255"
-                + "},"
-                + "\"filters\":{"
-                + "\"minAreaPx\":" + VidarConfig.PLATE_MIN_AREA_PX + ","
-                + "\"maxAreaPx\":" + VidarConfig.PLATE_MAX_AREA_PX + ","
-                + "\"minAspect\":" + VidarConfig.PLATE_MIN_ASPECT + ","
-                + "\"maxAspect\":" + VidarConfig.PLATE_MAX_ASPECT + ","
-                + "\"minRectangularity\":" + VidarConfig.PLATE_MIN_RECTANGULARITY + ","
-                + "\"minWhiteRatio\":" + VidarConfig.PLATE_MIN_WHITE_RATIO
-                + "},"
-                + "\"whiteDigit\":{"
-                + "\"sampleGrid\":" + VidarConfig.PLATE_WHITE_SAMPLE_GRID + ","
-                + "\"brightMin\":" + VidarConfig.PLATE_WHITE_BRIGHT_MIN + ","
-                + "\"spreadMax\":" + VidarConfig.PLATE_WHITE_SPREAD_MAX
-                + "}"
-                + "},{"
-                + "\"alliance\":\"blue\","
-                + "\"width\":12.0,"
-                + "\"hsv\":{"
-                + "\"hMin\":" + VidarConfig.PLATE_BLUE_H_MIN + ","
-                + "\"hMax\":" + VidarConfig.PLATE_BLUE_H_MAX + ","
-                + "\"sMin\":" + VidarConfig.PLATE_S_MIN + ","
-                + "\"sMax\":255,"
-                + "\"vMin\":" + VidarConfig.PLATE_V_MIN + ","
-                + "\"vMax\":255"
-                + "},"
-                + "\"filters\":{"
-                + "\"minAreaPx\":" + VidarConfig.PLATE_MIN_AREA_PX + ","
-                + "\"maxAreaPx\":" + VidarConfig.PLATE_MAX_AREA_PX + ","
-                + "\"minAspect\":" + VidarConfig.PLATE_MIN_ASPECT + ","
-                + "\"maxAspect\":" + VidarConfig.PLATE_MAX_ASPECT + ","
-                + "\"minRectangularity\":" + VidarConfig.PLATE_MIN_RECTANGULARITY + ","
-                + "\"minWhiteRatio\":" + VidarConfig.PLATE_MIN_WHITE_RATIO
-                + "},"
-                + "\"whiteDigit\":{"
-                + "\"sampleGrid\":" + VidarConfig.PLATE_WHITE_SAMPLE_GRID + ","
-                + "\"brightMin\":" + VidarConfig.PLATE_WHITE_BRIGHT_MIN + ","
-                + "\"spreadMax\":" + VidarConfig.PLATE_WHITE_SPREAD_MAX
-                + "}"
-                + "}]"
-                + "}";
-    }
-
-    public static String defaultRobotJson() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"robotName\":\"example-robot\",\"activeCameraIndex\":")
-                .append(VidarConfig.ACTIVE_CAMERA_INDEX)
-                .append(",\"cameraCount\":").append(VidarConfig.activeCameraCount())
-                .append(",\"dimensions\":{\"length\":13,\"width\":13,\"height\":18}")
-                .append(",\"alliance\":{")
-                .append("\"defaultAlliance\":\"")
-                .append(VidarConfig.DEFAULT_ALLIANCE.name().toLowerCase())
-                .append("\",\"colorSensorName\":\"")
-                .append(VidarConfig.ALLIANCE_COLOR_SENSOR)
-                .append("\",\"useColorSensor\":")
-                .append(VidarConfig.ALLIANCE_USE_COLOR_SENSOR)
-                .append(",\"allowRuntimeToggle\":")
-                .append(VidarConfig.ALLIANCE_ALLOW_RUNTIME_TOGGLE)
-                .append("},\"cameraDefaults\":");
-        appendCameraDefaultsJson(sb, VidarCameraProfile.FOUR_SIDES[0]);
-        sb.append(",\"mountDefaults\":{\"yawDeg\":0,\"pitchDeg\":-12,\"rollDeg\":0},\"cameras\":[");
-        int count = VidarConfig.activeCameraCount();
-        for (int i = 0; i < count; i++) {
-            if (i > 0) {
-                sb.append(',');
-            }
-            appendCameraEntryJson(sb, i, VidarConfig.CAMERA_NAMES[i], VidarCameraProfile.forIndex(i));
-        }
-        sb.append("]}");
-        return sb.toString();
-    }
-
-    private static void appendCameraDefaultsJson(StringBuilder sb, VidarCameraProfile profile) {
-        sb.append("{\"horizonRowPx\":").append(profile.horizonRowPx)
-                .append(",\"focalLengthPx\":").append(profile.focalLengthPx)
-                .append(",\"focalLengthYPx\":").append(profile.focalLengthYPx)
-                .append(",\"principalPointX\":").append(profile.principalPointX)
-                .append(",\"principalPointY\":").append(profile.principalPointY);
-        if (profile.calibrationWidth > 0) {
-            sb.append(",\"calibrationWidth\":").append(profile.calibrationWidth);
-        }
-        if (profile.calibrationHeight > 0) {
-            sb.append(",\"calibrationHeight\":").append(profile.calibrationHeight);
-        }
-        sb.append(",\"horizontalFovDeg\":").append(profile.horizontalFovDeg)
-                .append(",\"verticalFovDeg\":").append(profile.verticalFovDeg)
-                .append(",\"plateWidth\":").append(profile.plateWidth)
-                .append(",\"floorLut\":[");
-        for (int j = 0; j < profile.floorCyPx.length; j++) {
-            if (j > 0) {
-                sb.append(',');
-            }
-            sb.append("{\"cy\":").append(profile.floorCyPx[j])
-                    .append(",\"dist\":").append(profile.floorDist[j]).append('}');
-        }
-        sb.append("],\"roi\":");
-        appendRoiJson(sb, profile.roiConfig);
-        sb.append('}');
-    }
-
-    private static void appendRoiJson(StringBuilder sb, VidarCameraRoiConfig roi) {
-        sb.append("{\"element\":{\"lowerFraction\":").append(roi.elementLowerFraction)
-                .append(",\"enabled\":").append(roi.elementEnabled).append("},")
-                .append("\"plate\":{\"startFraction\":").append(roi.plateStartFraction)
-                .append(",\"bandFraction\":").append(roi.plateBandFraction)
-                .append(",\"enabled\":").append(roi.plateEnabled).append("},")
-                .append("\"tag\":{\"upperFraction\":").append(roi.tagUpperFraction)
-                .append(",\"enabled\":").append(roi.tagEnabled).append("}}");
-    }
-
-    private static void appendCameraEntryJson(
-            StringBuilder sb, int index, String webcamName, VidarCameraProfile profile) {
-        sb.append("{\"index\":").append(index)
-                .append(",\"webcamName\":\"").append(webcamName).append("\",")
-                .append("\"name\":\"").append(profile.name).append("\",")
-                .append("\"mount\":{\"bearingDeg\":").append(profile.bearingDeg)
-                .append(",\"x\":").append(profile.mountX)
-                .append(",\"y\":").append(profile.mountY)
-                .append(",\"z\":").append(profile.mountZ)
-                .append(",\"pitchDeg\":").append(profile.mountPitchDeg)
-                .append(",\"rollDeg\":").append(profile.mountRollDeg)
-                .append("}}");
-    }
 }
+

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/config/bundled/default-robot.json
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/config/bundled/default-robot.json
@@ -1,0 +1,80 @@
+{
+  "robotName": "example-robot",
+  "activeCameraIndex": 0,
+  "cameraCount": 1,
+  "dimensions": {
+    "length": 13,
+    "width": 13,
+    "height": 18
+  },
+  "alliance": {
+    "defaultAlliance": "red",
+    "colorSensorName": "alliance_color",
+    "useColorSensor": true,
+    "allowRuntimeToggle": true
+  },
+  "cameraDefaults": {
+    "horizonRowPx": 12,
+    "focalLengthPx": 340,
+    "focalLengthYPx": 340,
+    "principalPointX": 320,
+    "principalPointY": 240,
+    "calibrationWidth": 640,
+    "calibrationHeight": 480,
+    "horizontalFovDeg": 70,
+    "verticalFovDeg": 55,
+    "plateWidth": 12.0,
+    "floorLut": [
+      {
+        "cy": 95,
+        "dist": 12
+      },
+      {
+        "cy": 75,
+        "dist": 24
+      },
+      {
+        "cy": 55,
+        "dist": 36
+      },
+      {
+        "cy": 40,
+        "dist": 48
+      }
+    ],
+    "roi": {
+      "element": {
+        "lowerFraction": 0.65,
+        "enabled": true
+      },
+      "plate": {
+        "startFraction": 0.3,
+        "bandFraction": 0.4,
+        "enabled": true
+      },
+      "tag": {
+        "upperFraction": 0.65,
+        "enabled": true
+      }
+    }
+  },
+  "mountDefaults": {
+    "yawDeg": 0,
+    "pitchDeg": -12,
+    "rollDeg": 0
+  },
+  "cameras": [
+    {
+      "index": 0,
+      "webcamName": "Webcam 1",
+      "name": "front",
+      "mount": {
+        "bearingDeg": 0.0,
+        "x": 6.5,
+        "y": 0.0,
+        "z": 9.0,
+        "pitchDeg": -12
+      }
+    }
+  ]
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/config/bundled/default-season.json
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/config/bundled/default-season.json
@@ -1,0 +1,118 @@
+{
+  "seasonId": "2025-decode",
+  "seasonName": "DECODE 2025 \u2014 game elements and team plates",
+  "fusion": {
+    "minElementConfidence": 0.35,
+    "minPlateConfidence": 0.35,
+    "maxRangeMismatchRatio": 0.28
+  },
+  "elements": [
+    {
+      "id": "pollen",
+      "label": "Pollen element",
+      "diameter": 5.0,
+      "detector": "color_blob_with_local_hough",
+      "hsv": {
+        "hMin": 0,
+        "hMax": 179,
+        "sMin": 0,
+        "sMax": 85,
+        "vMin": 55,
+        "vMax": 255
+      },
+      "filters": {
+        "minAreaPx": 45,
+        "maxAreaPx": 12000,
+        "minWidthPx": 8,
+        "maxWidthPx": 80,
+        "minHeightPx": 8,
+        "maxHeightPx": 80,
+        "maxAspectRatio": 2.0,
+        "minCircularity": 0.55,
+        "minFillRatio": 0.55,
+        "minInteriorScore": 0.12
+      },
+      "interior": {
+        "brightMin": 90,
+        "spreadMax": 60,
+        "holeDarkMax": 45
+      },
+      "morphology": {
+        "erodePasses": 0,
+        "dilatePasses": 0,
+        "openPasses": 1,
+        "closePasses": 2
+      },
+      "hough": {
+        "dp": 1.2,
+        "minDist": 24.0,
+        "param1": 80.0,
+        "param2": 11.0,
+        "minRadius": 8,
+        "maxRadius": 36,
+        "minInterior": 0.14,
+        "minAreaPx": 45
+      }
+    }
+  ],
+  "plates": [
+    {
+      "alliance": "red",
+      "width": 12.0,
+      "hsv": {
+        "hMin": 0,
+        "hMax": 12,
+        "sMin": 80,
+        "sMax": 255,
+        "vMin": 60,
+        "vMax": 255
+      },
+      "hsvWrap": {
+        "hMin": 168,
+        "hMax": 179,
+        "sMin": 80,
+        "sMax": 255,
+        "vMin": 60,
+        "vMax": 255
+      },
+      "filters": {
+        "minAreaPx": 120,
+        "maxAreaPx": 12000,
+        "minAspect": 1.15,
+        "maxAspect": 4.5,
+        "minRectangularity": 0.45,
+        "minWhiteRatio": 0.12
+      },
+      "whiteDigit": {
+        "sampleGrid": 5,
+        "brightMin": 175,
+        "spreadMax": 55
+      }
+    },
+    {
+      "alliance": "blue",
+      "width": 12.0,
+      "hsv": {
+        "hMin": 95,
+        "hMax": 135,
+        "sMin": 80,
+        "sMax": 255,
+        "vMin": 60,
+        "vMax": 255
+      },
+      "filters": {
+        "minAreaPx": 120,
+        "maxAreaPx": 12000,
+        "minAspect": 1.15,
+        "maxAspect": 4.5,
+        "minRectangularity": 0.45,
+        "minWhiteRatio": 0.12
+      },
+      "whiteDigit": {
+        "sampleGrid": 5,
+        "brightMin": 175,
+        "spreadMax": 55
+      }
+    }
+  ]
+}

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,0 +1,30 @@
+"""Bundled Java default config assets match VidarConfig constants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vidar.config_loader import load_robot, load_season
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED_SEASON = ROOT / "teamcode/assets/vidar/default-season.json"
+BUNDLED_ROBOT = ROOT / "teamcode/assets/vidar/default-robot.json"
+
+
+def test_bundled_default_season_loads():
+    season = load_season(BUNDLED_SEASON)
+    assert season.season_id == "2025-decode"
+    assert len(season.elements) == 1
+    assert season.elements[0].id == "pollen"
+    assert len(season.plates) == 2
+    assert season.min_element_confidence == pytest.approx(0.35)
+    assert season.max_range_mismatch_ratio == pytest.approx(0.28)
+
+
+def test_bundled_default_robot_loads():
+    robot = load_robot(BUNDLED_ROBOT)
+    assert robot.robot_name == "example-robot"
+    assert len(robot.cameras) >= 1
+    assert robot.cameras[0].profile.focal_length_px == pytest.approx(340)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -10,6 +10,8 @@ from vidar.units import DistanceUnit
 ROOT = Path(__file__).resolve().parents[1]
 SEASON_FILES = sorted((ROOT / "config/seasons").glob("*.json"))
 ROBOT_FILES = sorted((ROOT / "config/robots").glob("example*.json"))
+BUNDLED_SEASON = ROOT / "teamcode/assets/vidar/default-season.json"
+BUNDLED_ROBOT = ROOT / "teamcode/assets/vidar/default-robot.json"
 
 
 def test_load_biobuzz_season():
@@ -100,3 +102,21 @@ def test_all_season_json_files_load(season_path: Path):
     for element in season.elements:
         assert element.diameter > 0
         assert element.detector in ElementDetectorType
+
+
+def test_bundled_default_season_matches_legacy_fusion_defaults():
+    """Bundled fallback mirrors VidarConfig fusion constants, not team season templates."""
+    bundled = load_season(BUNDLED_SEASON)
+    decode = load_season(ROOT / "config/seasons/2025-decode.json")
+    assert bundled.season_id == "2025-decode"
+    assert bundled.season_id == decode.season_id
+    assert bundled.elements[0].id == "pollen"
+    assert bundled.min_element_confidence == decode.min_element_confidence
+    assert bundled.max_range_mismatch_ratio == decode.max_range_mismatch_ratio
+
+
+def test_bundled_default_robot_loads():
+    robot = load_robot(BUNDLED_ROBOT)
+    assert robot.robot_name == "example-robot"
+    assert len(robot.cameras) >= 1
+    assert robot.cameras[0].profile.focal_length_px == pytest.approx(340)


### PR DESCRIPTION
## Summary
- Add \	eamcode/assets/vidar/default-season.json\ and \default-robot.json\
- Classpath copies under \idar/config/bundled/\ for \VidarConfigLoader\
- Delete \defaultSeasonJson()\ / \defaultRobotJson()\ string builders (~200 LOC)
- Document \VidarConfig\ as hardware-only fallbacks; update deploy docs and tests

## Depends on
- Merge PR3 (geometry migration) first

## Test plan
- [x] \pytest\ passes (97 tests, includes \	est_config_defaults.py\)
- [ ] Copy \	eamcode/assets/vidar/\ → \TeamCode/src/main/assets/vidar/\ in FTC project
- [ ] Android Studio compile smoke test
- [ ] OpMode init without team assets falls back to bundled defaults


Made with [Cursor](https://cursor.com)