### PR TITLE
Add Pedro pose bridge with event-id gated corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Feature-level labels and maturity notes: [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DES
 | [Coordinate frames](docs/COORDINATE_FRAMES.md) | Frames, transforms, intrinsics, validation |
 | [Teaching guide](docs/TEACHING.md) | Java lessons for Control Hub development |
 | [Roadmap](docs/ROADMAP.md) | Multi-cam USB wiring, validation, optional pathing integration |
+| [Pedro integration](docs/PEDRO_INTEGRATION.md) | Pose bridge + sparse tag correction with Pedro Pathing |
 | [Browser simulator](#browser-simulator) | Tune ROIs and colors before deploying to the hub |
 | [Robot templates](config/robots/README.md) | SVPRO vs C920 example `robot.json` files |
 | [Pedro Pathing](https://pedropathing.com/) | Optional: one supported autonomous stack (not required) |

--- a/docs/API.md
+++ b/docs/API.md
@@ -311,6 +311,27 @@ try {
 
 Motion-corrected tracks require an odom supplier at `create()`. Field pose for tracks extrapolates from odom between tag fixes; optional `setFieldPoseSupplier()` for Pedro-primary pose.
 
+### Pedro Pathing (optional)
+
+No Pedro dependency in ViDAR. Use `vidar.integration`:
+
+```
+VidarPedroPoseBridge.fromPose2D / toPose2D / asPose2DSupplier(...)
+// Gate on correction event id; inject pose re-propagated to current odom
+VidarPedroCorrectionTracker.poll(
+    spatial.lastTagCorrectionNanos(),
+    spatial.tagCorrectedFieldPoseNow())
+```
+
+| Method | Use |
+|--------|-----|
+| `fieldPose()` | Snapshot field (Pedro if `setFieldPoseSupplier` set) |
+| `fusedFieldPose()` | Gate-accepted tag fix at fuse-time (never Pedro; pinned) |
+| `lastTagCorrectionNanos()` | Novelty event id for the tracker (pinned) |
+| `tagCorrectedFieldPoseNow()` | Fused fix advanced to odom at `update()` — for `follower.setPose` |
+
+See [PEDRO_INTEGRATION.md](PEDRO_INTEGRATION.md) and OpMode **ViDAR: Pedro Bridge Sample**.
+
 ### `VidarSpatialPoint`
 
 | Field | Type | Notes |

--- a/docs/JAVA_PACKAGE_MAP.md
+++ b/docs/JAVA_PACKAGE_MAP.md
@@ -11,7 +11,7 @@
 | `VidarAlliance`, `VidarDistanceUnit`, `VidarElementDetectorType`, `VidarElementShape`, `VidarOffensiveLane` | Enums |
 | `VidarGeometry`, `VidarCoordinateFrames` | Range and field/robot transforms |
 | `VidarSpatialOpModeBase` | Shared OpMode helpers (alliance init, telemetry) |
-| `VidarTeleOp`, `VidarDiscoverOpMode`, `VidarAutoSeekOpMode`, `VidarRoiCalibrationOpMode` | Built-in OpModes |
+| `VidarTeleOp`, `VidarDiscoverOpMode`, `VidarAutoSeekOpMode`, `VidarRoiCalibrationOpMode`, `VidarPedroBridgeSampleOpMode` | Built-in OpModes |
 
 ## Subpackages
 
@@ -19,6 +19,7 @@
 |---------|----------------|-------------|
 | `vidar.runtime` | Process runtime + camera attachment | `VidarRuntime`, `VidarVisionAttachment`, `VidarObservationWorker`, `RuntimeBootstrap`, `VidarVision`, `VidarRuntimeConfig` |
 | `vidar.api` | Student diagnostics | `VidarDiagnostics` |
+| `vidar.integration` | Optional pathing bridges (no hard deps) | `VidarPedroPose`, `VidarPedroPoseBridge`, `VidarPedroCorrectionTracker` |
 | `vidar.detect` | Contour / color-blob pipeline | `VidarContourProcessor`, `ElementDetector`, `PlateDetector` |
 | `vidar.tag` | AprilTag scout, crop decode, gates | `VidarAdaptiveTagProcessor`, `VidarTagDecodeWorker`, `TagDecodeBudget` |
 | `vidar.fusion` | Localization, temporal filter, multi-camera fusion | `VidarFusionEngine`, `VidarLocalizationFusion`, `MultiCameraFusion`, `FieldPoseContext`, `VidarVisionFusion` |

--- a/docs/PEDRO_INTEGRATION.md
+++ b/docs/PEDRO_INTEGRATION.md
@@ -1,0 +1,142 @@
+# Pedro Pathing + ViDAR
+
+ViDAR does **not** depend on Pedro Pathing. Pedro owns continuous pose and path following; ViDAR owns robot-space awareness and sparse AprilTag fixes. This doc shows how to wire them with the bridge in `vidar.integration`.
+
+## Classes (no Pedro Maven required)
+
+| Class | Role |
+|-------|------|
+| `VidarPedroPose` | Inches + heading **radians** (Pedro `Pose` shape) |
+| `VidarPedroPoseBridge` | `Pose2D` ↔ `VidarPedroPose` / suppliers |
+| `VidarPedroCorrectionTracker` | Gate on correction **event id**; return pose **corrected to now** |
+| `VidarPedroBridgeSampleOpMode` | Compilable loop sample with an in-memory follower stand-in |
+
+## Latency: why `fieldPose()` alone is wrong for `setPose`
+
+AprilTag imagery is old by the time a correction reaches Pedro:
+
+```
+capture ──decode/fuse (≤1 Hz)──► fused anchor ──OpMode lag──► setPose
+   │                                    │                         │
+   fieldPoseAtCapture          backdated to odom@fuse      must re-propagate
+                                                         to Pedro pose @ now
+```
+
+| Step | What ViDAR does |
+|------|-----------------|
+| 1. Capture | Tag stores `fieldPoseAtCapture` + `captureTimeNanos` |
+| 2. Fuse | `odomHistory.at(capture)` + gates → stamp **odom-at-fuse once**; `lastTagCorrectionNanos()` advances |
+| 3. Snapshot | `spatial.fusedFieldPose()` is the fuse-time anchor (not Pedro) |
+| 4. setPose | `tagCorrectedFieldPoseNow()` re-propagates fuse → current odom |
+
+**Do not** gate novelty on `spatial.fieldPose()` when Pedro is wired via `setFieldPoseSupplier` — that value is the live Pedro pose and will re-fire `setPose` as you drive.
+
+**Do not** call `follower.setPose` with raw `fusedFieldPose()` — that plants the robot where it was at fuse time.
+
+## Loop contract
+
+```
+follower.update();
+spatial.update();
+correction = tracker.poll(
+        spatial.lastTagCorrectionNanos(),     // novelty: event id (0 = none)
+        spatial.tagCorrectedFieldPoseNow());  // inject: re-propagated to now
+if (correction != null) {
+    follower.setPose(new Pose(correction.x, correction.y, correction.headingRad));
+}
+```
+
+Cooldown lives in localization gates only — the tracker does not add a second timer.
+
+## Team wiring (real Pedro)
+
+```java
+import com.pedropathing.follower.Follower;
+import com.pedropathing.geometry.Pose;
+import org.firstinspires.ftc.teamcode.vidar.VidarSpatial;
+import org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroCorrectionTracker;
+import org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroPose;
+import org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroPoseBridge;
+
+Follower follower = Constants.createFollower(hardwareMap);
+follower.setStartingPose(startPose);
+
+VidarSpatial spatial = VidarSpatial.create(
+        hardwareMap,
+        VidarPedroPoseBridge.asPose2DSupplier(
+                () -> follower.getPose().getX(),
+                () -> follower.getPose().getY(),
+                () -> follower.getPose().getHeading()),
+        alliance::get);
+// Continuous field pose for world tracks only — not the fused-tag anchor
+spatial.setFieldPoseSupplier(
+        VidarPedroPoseBridge.asPose2DSupplier(
+                () -> follower.getPose().getX(),
+                () -> follower.getPose().getY(),
+                () -> follower.getPose().getHeading()));
+
+VidarPedroCorrectionTracker corrections = new VidarPedroCorrectionTracker();
+
+while (opModeIsActive()) {
+    follower.update();
+    spatial.update();
+
+    if (spatial.intakeBlocked()) {
+        // slow / hold — team FSM
+    }
+
+    VidarPedroPose fix = corrections.poll(
+            spatial.lastTagCorrectionNanos(),
+            spatial.tagCorrectedFieldPoseNow());
+    if (fix != null) {
+        follower.setPose(new Pose(fix.x, fix.y, fix.headingRad));
+    }
+}
+spatial.close();
+```
+
+### API cheat sheet
+
+| Method | Meaning |
+|--------|---------|
+| `fieldPose()` | Snapshot field pose (Pedro if `setFieldPoseSupplier` set) |
+| `fusedFieldPose()` | Last gate-accepted tag fix at fuse-time (never Pedro; pinned) |
+| `lastTagCorrectionNanos()` | Event id for tracker novelty (0 = none yet; pinned) |
+| `tagCorrectedFieldPoseNow()` | Fused fix re-propagated to odom-at-publish (pinned) |
+
+### Manual backdate (advanced)
+
+```java
+Pose2D atCapture = tag.fieldPoseAtCapture;
+Pose2D odomThen = /* pose at tag.captureTimeNanos */;
+Pose2D odomNow = VidarPedroPoseBridge.toPose2D(
+        follower.getPose().getX(),
+        follower.getPose().getY(),
+        follower.getPose().getHeading());
+Pose2D forSetPose = VidarPedroCorrectionTracker.backdateToNow(atCapture, odomThen, odomNow);
+```
+
+## Frames and units
+
+| | ViDAR `Pose2D` | Pedro `Pose` |
+|--|----------------|--------------|
+| Position | inches | inches (typical) |
+| Heading | degrees on the object (query with `AngleUnit`) | **radians** |
+| Field axes | FTC center origin (+X right, +Y forward) | Team Pedro coordinate system |
+
+The bridge assumes **the same field frame** your Pedro constants already use. If you rely on Pedro `CoordinateSystem` converters, convert before wrapping into `VidarPedroPose` / after reading `follower.getPose()`.
+
+## Run the sample
+
+1. Deploy and open **ViDAR: Pedro Bridge Sample**.
+2. Confirm telemetry: fused anchor vs corrected-now (Δ), correction id.
+3. Copy the loop into your Pedro auto; replace the stand-in with `Follower`.
+
+Correction fields (`fusedFieldPose`, `lastTagCorrectionNanos`, `tagCorrectedFieldPoseNow`) are pinned on `spatial.update()` under the runtime lock, using the odom sample at pin time.
+
+## Related
+
+- [ROADMAP.md](ROADMAP.md) Phase 4 — localization split
+- [API.md](API.md) — `VidarSpatial` contract
+- [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md) — runtime / attachment lifecycle
+- `VidarMotionCorrection` / `VidarOdomHistory` — capture→now math

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,18 +123,20 @@ ViDAR outputs:
 - `VidarTagObservation` + `getBackdatedFieldPose(odomNow)` — sparse absolute fixes
 - `VidarWorldModel` — robot-relative obstacles and game elements
 
-Suggested split:
+**Bridge (in-repo):** `vidar.integration` — `VidarPedroPoseBridge` + `VidarPedroCorrectionTracker` + sample OpMode. See [PEDRO_INTEGRATION.md](PEDRO_INTEGRATION.md). No Pedro Maven dependency.
+
+Suggested team split (optional beyond the bridge):
 
 ```
 teamcode/.../localization/
   RobotPoseFusion.java    // odom + IMU + optional Pinpoint
-  TagCorrection.java      // consumes ViDAR tag fixes
+  TagCorrection.java      // thin wrapper around VidarPedroCorrectionTracker
   FieldPoseProvider.java  // single Pose2D for Pedro
 ```
 
-Pedro consumes `FieldPoseProvider.get()` for path following; assisted modes read `VidarWorldModel` for reactive overrides (slow near foe, abort intake if blocked).
+Pedro consumes continuous localizer pose for path following; assisted modes read `VidarWorldModel` / `VidarSpatial` for reactive overrides (slow near foe, abort intake if blocked).
 
-**Do not** run full AprilTag decode inside Pedro’s control loop — keep ViDAR’s 2 s gate.
+**Do not** run full AprilTag decode inside Pedro’s control loop — keep ViDAR’s decode budget / gates.
 
 ---
 

--- a/docs/TEACHING.md
+++ b/docs/TEACHING.md
@@ -90,6 +90,7 @@ Ideas in order of difficulty:
 | Autonomous grab line | New `@Autonomous` OpMode, no gamepad |
 | Custom HSV color | Add or edit an entry in `config/seasons/*.json` |
 | Second / third / fourth camera | Raise `VidarConfig.CAMERA_COUNT`, name webcams `Webcam 1`…`N`, add mounts in `robot.json` (or bundled defaults) |
+| Pedro Pathing bridge | Copy loop from [PEDRO_INTEGRATION.md](PEDRO_INTEGRATION.md) / **ViDAR: Pedro Bridge Sample** |
 
 ## File roles (teach students this map)
 

--- a/java-pure/src/stub/java/org/firstinspires/ftc/robotcore/external/navigation/Pose2D.java
+++ b/java-pure/src/stub/java/org/firstinspires/ftc/robotcore/external/navigation/Pose2D.java
@@ -1,26 +1,62 @@
 package org.firstinspires.ftc.robotcore.external.navigation;
 
-/** Minimal stub for JVM unit tests. */
+/** Minimal stub for JVM unit tests — stores inches and radians internally. */
 public final class Pose2D {
-    private final double x;
-    private final double y;
-    private final double heading;
+    private final double xInches;
+    private final double yInches;
+    private final double headingRadians;
 
     public Pose2D(DistanceUnit distanceUnit, double x, double y, AngleUnit angleUnit, double heading) {
-        this.x = x;
-        this.y = y;
-        this.heading = heading;
+        this.xInches = toInches(distanceUnit, x);
+        this.yInches = toInches(distanceUnit, y);
+        this.headingRadians = toRadians(angleUnit, heading);
     }
 
     public double getX(DistanceUnit unit) {
-        return x;
+        return fromInches(unit, xInches);
     }
 
     public double getY(DistanceUnit unit) {
-        return y;
+        return fromInches(unit, yInches);
     }
 
     public double getHeading(AngleUnit unit) {
+        if (unit == AngleUnit.DEGREES) {
+            return Math.toDegrees(headingRadians);
+        }
+        return headingRadians;
+    }
+
+    private static double toInches(DistanceUnit unit, double value) {
+        if (unit == DistanceUnit.MM) {
+            return value / 25.4;
+        }
+        if (unit == DistanceUnit.CM) {
+            return value / 2.54;
+        }
+        if (unit == DistanceUnit.METER) {
+            return value / 0.0254;
+        }
+        return value; // INCH
+    }
+
+    private static double fromInches(DistanceUnit unit, double inches) {
+        if (unit == DistanceUnit.MM) {
+            return inches * 25.4;
+        }
+        if (unit == DistanceUnit.CM) {
+            return inches * 2.54;
+        }
+        if (unit == DistanceUnit.METER) {
+            return inches * 0.0254;
+        }
+        return inches;
+    }
+
+    private static double toRadians(AngleUnit unit, double heading) {
+        if (unit == AngleUnit.DEGREES) {
+            return Math.toRadians(heading);
+        }
         return heading;
     }
 }

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/fusion/LocalizationFusionTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/fusion/LocalizationFusionTest.java
@@ -20,7 +20,8 @@ class LocalizationFusionTest {
                 45, 40, 0.9, "cam", VidarFrameRegions.HorizontalBand.MIDDLE, 100, 100, 0);
         assertFalse(fusion.wouldScoutAlterPose(scout));
         Pose2D before = fusion.lastFusedFieldPose();
-        fusion.fusedFieldPoseNow(null, scout, null, null);
+        VidarLocalizationFusion.Result result = fusion.fusedFieldPoseNow(null, scout, null, null);
+        assertFalse(result.acceptedNewCorrection);
         assertEquals(before, fusion.lastFusedFieldPose());
     }
 
@@ -28,20 +29,60 @@ class LocalizationFusionTest {
     void decodedTagCanUpdatePose() {
         VidarLocalizationFusion fusion = new VidarLocalizationFusion();
         Pose2D fieldAtCapture = new Pose2D(DistanceUnit.INCH, 20, 30, AngleUnit.DEGREES, 90);
-        VidarTagObservation tag = new VidarTagObservation(
+        VidarTagObservation tag = newTag(fieldAtCapture, System.nanoTime());
+        Pose2D odom = new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0);
+        VidarLocalizationFusion.Result result = fusion.fusedFieldPoseNow(tag, null, odom, odom);
+        assertTrue(result.acceptedNewCorrection);
+        assertNotNull(result.pose);
+        assertEquals(20.0, result.pose.getX(DistanceUnit.INCH), 0.01);
+        assertEquals(30.0, result.pose.getY(DistanceUnit.INCH), 0.01);
+        assertTrue(result.correctionNanos > 0);
+        assertEquals(result.correctionNanos, fusion.lastCorrectionNanos());
+    }
+
+    @Test
+    void rejectedRepeatDoesNotAdvanceCorrectionNanos() {
+        VidarLocalizationFusion fusion = new VidarLocalizationFusion();
+        Pose2D fieldAtCapture = new Pose2D(DistanceUnit.INCH, 20, 30, AngleUnit.DEGREES, 90);
+        Pose2D odom = new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0);
+        VidarLocalizationFusion.Result first =
+                fusion.fusedFieldPoseNow(newTag(fieldAtCapture, System.nanoTime()), null, odom, odom);
+        assertTrue(first.acceptedNewCorrection);
+        long nanos = fusion.lastCorrectionNanos();
+
+        // Same decode within cooldown — must not accept or re-stamp.
+        VidarLocalizationFusion.Result second =
+                fusion.fusedFieldPoseNow(newTag(fieldAtCapture, System.nanoTime()), null, odom, odom);
+        assertFalse(second.acceptedNewCorrection);
+        assertEquals(nanos, fusion.lastCorrectionNanos());
+        assertEquals(first.pose.getX(DistanceUnit.INCH), second.pose.getX(DistanceUnit.INCH), 1e-9);
+    }
+
+    @Test
+    void gatedPropagationUsesOdomStampAtAcceptNotLaterTicks() {
+        Pose2D anchor = new Pose2D(DistanceUnit.INCH, 20, 0, AngleUnit.DEGREES, 0);
+        Pose2D odomAtFuse = new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0);
+        Pose2D odomLater = new Pose2D(DistanceUnit.INCH, 3, 1, AngleUnit.DEGREES, 10);
+        // Simulate correct stamp behavior: keep odomAtFuse fixed across later ticks.
+        Pose2D corrected = VidarMotionCorrection.robotFieldPoseNow(anchor, odomAtFuse, odomLater);
+        assertEquals(23.0, corrected.getX(DistanceUnit.INCH), 1e-9);
+        assertEquals(1.0, corrected.getY(DistanceUnit.INCH), 1e-9);
+        assertEquals(10.0, corrected.getHeading(AngleUnit.DEGREES), 1e-9);
+        // Wrong stamp (odomAtFuse overwritten to later) collapses to frozen fuse pose:
+        Pose2D collapsed = VidarMotionCorrection.robotFieldPoseNow(anchor, odomLater, odomLater);
+        assertEquals(20.0, collapsed.getX(DistanceUnit.INCH), 1e-9);
+    }
+
+    private static VidarTagObservation newTag(Pose2D fieldAtCapture, long captureNanos) {
+        return new VidarTagObservation(
                 1,
                 fieldAtCapture,
-                System.nanoTime(),
+                captureNanos,
                 "cam",
                 320,
                 240,
                 VidarFrameRegions.HorizontalBand.MIDDLE,
                 2,
                 500);
-        Pose2D odom = new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0);
-        Pose2D fused = fusion.fusedFieldPoseNow(tag, null, odom, odom);
-        assertNotNull(fused);
-        assertEquals(20.0, fused.getX(DistanceUnit.INCH), 0.01);
-        assertEquals(30.0, fused.getY(DistanceUnit.INCH), 0.01);
     }
 }

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroCorrectionTrackerTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroCorrectionTrackerTest.java
@@ -1,0 +1,74 @@
+package org.firstinspires.ftc.teamcode.vidar.integration;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VidarPedroCorrectionTrackerTest {
+
+    @Test
+    void firstEventIdIsApplied() {
+        VidarPedroCorrectionTracker tracker = new VidarPedroCorrectionTracker();
+        Pose2D now = new Pose2D(DistanceUnit.INCH, 11, 20, AngleUnit.DEGREES, 0);
+        VidarPedroPose applied = tracker.poll(100L, now);
+        assertNotNull(applied);
+        assertEquals(11.0, applied.x, 1e-9);
+        assertEquals(100L, tracker.lastAppliedCorrectionNanos());
+    }
+
+    @Test
+    void sameEventIdIsNotReappliedEvenIfPoseMoves() {
+        VidarPedroCorrectionTracker tracker = new VidarPedroCorrectionTracker();
+        Pose2D now1 = new Pose2D(DistanceUnit.INCH, 10, 20, AngleUnit.DEGREES, 0);
+        Pose2D now2 = new Pose2D(DistanceUnit.INCH, 12, 20, AngleUnit.DEGREES, 0);
+        assertNotNull(tracker.poll(100L, now1));
+        assertNull(tracker.poll(100L, now2));
+    }
+
+    @Test
+    void newEventIdAppliesUpdatedPose() {
+        VidarPedroCorrectionTracker tracker = new VidarPedroCorrectionTracker();
+        Pose2D a = new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0);
+        Pose2D bNow = new Pose2D(DistanceUnit.INCH, 5.5, 0, AngleUnit.DEGREES, 0);
+        assertNotNull(tracker.poll(100L, a));
+        VidarPedroPose next = tracker.poll(200L, bNow);
+        assertNotNull(next);
+        assertEquals(5.5, next.x, 1e-9);
+        assertEquals(200L, tracker.lastAppliedCorrectionNanos());
+    }
+
+    @Test
+    void zeroOrNullSkipped() {
+        VidarPedroCorrectionTracker tracker = new VidarPedroCorrectionTracker();
+        Pose2D pose = new Pose2D(DistanceUnit.INCH, 1, 0, AngleUnit.DEGREES, 0);
+        assertNull(tracker.poll(0L, pose));
+        assertNull(tracker.poll(50L, null));
+    }
+
+    @Test
+    void pedroLivePoseMustNotBeUsedAsEventId() {
+        // Regression: gating on changing Pose2D (Pedro fieldPose) would re-fire every move.
+        // Event-id API ignores pose motion without a new correctionNanos.
+        VidarPedroCorrectionTracker tracker = new VidarPedroCorrectionTracker();
+        Pose2D pedroMoving = new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0);
+        assertNotNull(tracker.poll(1L, pedroMoving));
+        for (int i = 1; i <= 10; i++) {
+            Pose2D later = new Pose2D(DistanceUnit.INCH, i, 0, AngleUnit.DEGREES, 0);
+            assertNull(tracker.poll(1L, later), "drive motion must not re-inject setPose");
+        }
+    }
+
+    @Test
+    void backdateToNowAddsOdomDelta() {
+        Pose2D atCapture = new Pose2D(DistanceUnit.INCH, 10, 0, AngleUnit.DEGREES, 0);
+        Pose2D odomThen = new Pose2D(DistanceUnit.INCH, 0, 0, AngleUnit.DEGREES, 0);
+        Pose2D odomNow = new Pose2D(DistanceUnit.INCH, 3, 1, AngleUnit.DEGREES, 10);
+        Pose2D corrected = VidarPedroCorrectionTracker.backdateToNow(atCapture, odomThen, odomNow);
+        assertEquals(13.0, corrected.getX(DistanceUnit.INCH), 1e-9);
+        assertEquals(1.0, corrected.getY(DistanceUnit.INCH), 1e-9);
+        assertEquals(10.0, corrected.getHeading(AngleUnit.DEGREES), 1e-9);
+    }
+}

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroPoseBridgeTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroPoseBridgeTest.java
@@ -1,0 +1,42 @@
+package org.firstinspires.ftc.teamcode.vidar.integration;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VidarPedroPoseBridgeTest {
+
+    @Test
+    void roundTripPreservesInchesAndRadians() {
+        Pose2D original = new Pose2D(DistanceUnit.INCH, 12.5, -4.0, AngleUnit.DEGREES, 90.0);
+        VidarPedroPose pedro = VidarPedroPoseBridge.fromPose2D(original);
+        assertNotNull(pedro);
+        assertEquals(12.5, pedro.x, 1e-9);
+        assertEquals(-4.0, pedro.y, 1e-9);
+        assertEquals(Math.toRadians(90.0), pedro.headingRad, 1e-9);
+
+        Pose2D back = VidarPedroPoseBridge.toPose2D(pedro);
+        assertEquals(12.5, back.getX(DistanceUnit.INCH), 1e-9);
+        assertEquals(-4.0, back.getY(DistanceUnit.INCH), 1e-9);
+        assertEquals(90.0, back.getHeading(AngleUnit.DEGREES), 1e-6);
+    }
+
+    @Test
+    void nullSafe() {
+        assertNull(VidarPedroPoseBridge.fromPose2D(null));
+        assertNull(VidarPedroPoseBridge.toPose2D((VidarPedroPose) null));
+        assertNull(VidarPedroPoseBridge.asPose2DSupplier(null));
+    }
+
+    @Test
+    void componentSupplierBuildsPose2D() {
+        Pose2D pose = VidarPedroPoseBridge.asPose2DSupplier(
+                () -> 1.0, () -> 2.0, () -> Math.PI / 2.0).get();
+        assertEquals(1.0, pose.getX(DistanceUnit.INCH), 1e-9);
+        assertEquals(2.0, pose.getY(DistanceUnit.INCH), 1e-9);
+        assertEquals(90.0, pose.getHeading(AngleUnit.DEGREES), 1e-6);
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarPedroBridgeSampleOpMode.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarPedroBridgeSampleOpMode.java
@@ -1,0 +1,115 @@
+package org.firstinspires.ftc.teamcode.vidar;
+
+import org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroCorrectionTracker;
+import org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroPose;
+import org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroPoseBridge;
+import org.firstinspires.ftc.teamcode.vidar.runtime.VidarAllianceSelector;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Compilable sample: wire ViDAR to a pathing follower without a Pedro Maven dependency.
+ *
+ * <p>Uses an in-memory pose stand-in for {@code Follower.getPose()/setPose()}. In a Pedro project,
+ * replace {@link #tickFollower} / {@link #applyFollowerPose} with your real {@code Follower}
+ * (see {@code docs/PEDRO_INTEGRATION.md}).
+ *
+ * <p>Loop contract:
+ * <ol>
+ *   <li>Update pathing / odom (Pedro {@code follower.update()})</li>
+ *   <li>{@code spatial.update()} - pin snapshot</li>
+ *   <li>Read {@code elements()}/{@code foes()} for assists</li>
+ *   <li>Sparse tag correction via {@link VidarPedroCorrectionTracker} (event-id gate)</li>
+ * </ol>
+ */
+@TeleOp(name = "ViDAR: Pedro Bridge Sample", group = "ViDAR")
+public class VidarPedroBridgeSampleOpMode extends VidarSpatialOpModeBase {
+
+    private final AtomicReference<VidarPedroPose> followerPose =
+            new AtomicReference<>(new VidarPedroPose(0, 0, 0));
+    private final VidarPedroCorrectionTracker corrections = new VidarPedroCorrectionTracker();
+
+    private VidarSpatial spatial;
+    private VidarAllianceSelector alliance;
+
+    @Override
+    public void runOpMode() {
+        alliance = new VidarAllianceSelector(hardwareMap);
+
+        spatial = VidarSpatial.createWithBundledDefaults(
+                hardwareMap,
+                VidarPedroPoseBridge.asPose2DSupplier(followerPose::get),
+                alliance::get);
+        // Continuous field pose for world tracks — does NOT replace fusedFieldPose().
+        spatial.setFieldPoseSupplier(VidarPedroPoseBridge.asPose2DSupplier(followerPose::get));
+
+        telemetry.addLine("ViDAR <-> Pedro bridge sample (in-memory follower stand-in)");
+        telemetry.addLine("Replace stand-in with Follower - see docs/PEDRO_INTEGRATION.md");
+        telemetry.update();
+
+        pollAllianceInit(alliance, gamepad1);
+        waitForStart();
+
+        while (opModeIsActive()) {
+            alliance.pollRuntime(gamepad1);
+
+            tickFollower();
+            spatial.update();
+
+            VidarSpatialPoint nearest = spatial.nearestElement();
+            boolean blocked = spatial.intakeBlocked();
+
+            long correctionId = spatial.lastTagCorrectionNanos();
+            Pose2D fusedAnchor = spatial.fusedFieldPose();
+            Pose2D correctedNow = spatial.tagCorrectedFieldPoseNow();
+            VidarPedroPose correction = corrections.poll(correctionId, correctedNow);
+            if (correction != null) {
+                applyFollowerPose(correction);
+            }
+
+            telemetry.addData("Alliance", alliance.formatStatus());
+            telemetry.addData("Follower pose", followerPose.get());
+            telemetry.addData("Fused anchor", formatFieldPose(fusedAnchor));
+            telemetry.addData("Corrected now", formatFieldPose(correctedNow));
+            telemetry.addData("Fuse→now Δ", deltaInches(fusedAnchor, correctedNow));
+            telemetry.addData("Correction id", correctionId);
+            telemetry.addData("Correction applied", correction != null ? correction : "-");
+            telemetry.addData("Nearest element", nearest == null ? "-" : nearest);
+            telemetry.addData("Intake blocked", blocked);
+            telemetry.update();
+        }
+
+        spatial.close();
+    }
+
+    /**
+     * Stand-in for {@code follower.update()} — drifts slowly so Driver Station can show fused
+     * anchor vs corrected-now diverge between sparse tag fixes.
+     */
+    private void tickFollower() {
+        // Pedro: follower.update();
+        VidarPedroPose cur = followerPose.get();
+        followerPose.set(new VidarPedroPose(cur.x + 0.05, cur.y, cur.headingRad));
+    }
+
+    private void applyFollowerPose(VidarPedroPose pose) {
+        // Pedro: follower.setPose(new Pose(pose.x, pose.y, pose.headingRad));
+        followerPose.set(pose);
+    }
+
+    private static String deltaInches(Pose2D fused, Pose2D corrected) {
+        if (fused == null || corrected == null) {
+            return "-";
+        }
+        double dx = corrected.getX(org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit.INCH)
+                - fused.getX(org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit.INCH);
+        double dy = corrected.getY(org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit.INCH)
+                - fused.getY(org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit.INCH);
+        double dh = corrected.getHeading(AngleUnit.DEGREES) - fused.getHeading(AngleUnit.DEGREES);
+        return String.format("dx=%.2f dy=%.2f dh=%.1f", dx, dy, dh);
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
@@ -221,6 +221,40 @@ public final class VidarSpatial {
         return snapshot.fieldPose;
     }
 
+    /**
+     * Last gate-accepted tag fused pose (freeze at fuse-time). Never uses
+     * {@link #setFieldPoseSupplier} — safe as a Pedro novelty / telemetry anchor when Pedro is
+     * also wired as the continuous field supplier. Pinned with {@link #update()}.
+     */
+    public Pose2D fusedFieldPose() {
+        return snapshot.fusedFieldPose;
+    }
+
+    /**
+     * {@link System#nanoTime()} of the last gate-accepted tag correction (0 = none). Use with
+     * {@link org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroCorrectionTracker} so
+     * novelty is event-based, not pose-epsilon based. Pinned with {@link #update()}.
+     */
+    public long lastTagCorrectionNanos() {
+        return snapshot.lastTagCorrectionNanos;
+    }
+
+    /**
+     * Gated tag-fused field pose re-propagated to the odom sample at the last publish.
+     *
+     * <p>Unlike {@link #fieldPose()}, this advances the last <em>gate-accepted</em> fix from
+     * odom-at-fuse to odom-at-publish. It bypasses {@link #setFieldPoseSupplier} so Pedro can
+     * still supply continuous pose for world tracks while corrections stay ViDAR-derived. Use for
+     * {@code follower.setPose} — see
+     * {@link org.firstinspires.ftc.teamcode.vidar.integration.VidarPedroCorrectionTracker}.
+     *
+     * <p>Pinned with {@link #update()} so a mid-loop worker tick cannot change the inject pose.
+     * Returns {@code null} until a tag fix has passed localization gates.
+     */
+    public Pose2D tagCorrectedFieldPoseNow() {
+        return snapshot.tagCorrectedFieldPoseNow;
+    }
+
     public Pose2D robotPose() {
         Supplier<Pose2D> odom = runtime.fieldPoseContext().odomSupplier();
         return odom != null ? odom.get() : null;

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/frame/VidarSpatialSnapshot.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/frame/VidarSpatialSnapshot.java
@@ -29,7 +29,10 @@ public final class VidarSpatialSnapshot {
             Collections.emptyList(),
             false,
             null,
-            0);
+            0,
+            null,
+            null,
+            0L);
 
     public final List<VidarSpatialPoint> elements;
     public final List<VidarSpatialPoint> allies;
@@ -37,6 +40,11 @@ public final class VidarSpatialSnapshot {
     public final boolean intakeBlocked;
     public final Pose2D fieldPose;
     public final int trackCount;
+    /** Gate-accepted tag fuse at fuse-time (never external Pedro supplier). */
+    public final Pose2D fusedFieldPose;
+    /** Fused fix re-propagated to odom-at-publish; stable for one {@code update()} pin. */
+    public final Pose2D tagCorrectedFieldPoseNow;
+    public final long lastTagCorrectionNanos;
 
     public VidarSpatialSnapshot(
             List<VidarSpatialPoint> elements,
@@ -44,17 +52,33 @@ public final class VidarSpatialSnapshot {
             List<VidarSpatialPoint> foes,
             boolean intakeBlocked,
             Pose2D fieldPose,
-            int trackCount) {
+            int trackCount,
+            Pose2D fusedFieldPose,
+            Pose2D tagCorrectedFieldPoseNow,
+            long lastTagCorrectionNanos) {
         this.elements = Collections.unmodifiableList(new ArrayList<>(elements));
         this.allies = Collections.unmodifiableList(new ArrayList<>(allies));
         this.foes = Collections.unmodifiableList(new ArrayList<>(foes));
         this.intakeBlocked = intakeBlocked;
         this.fieldPose = fieldPose;
         this.trackCount = trackCount;
+        this.fusedFieldPose = fusedFieldPose;
+        this.tagCorrectedFieldPoseNow = tagCorrectedFieldPoseNow;
+        this.lastTagCorrectionNanos = lastTagCorrectionNanos;
     }
 
     public static VidarSpatialSnapshot empty() {
         return EMPTY;
+    }
+
+    /** Copy with refreshed tag-correction fields (used when pinning an OpMode loop). */
+    public VidarSpatialSnapshot withCorrections(
+            Pose2D fusedFieldPose,
+            Pose2D tagCorrectedFieldPoseNow,
+            long lastTagCorrectionNanos) {
+        return new VidarSpatialSnapshot(
+                elements, allies, foes, intakeBlocked, fieldPose, trackCount,
+                fusedFieldPose, tagCorrectedFieldPoseNow, lastTagCorrectionNanos);
     }
 
     public static VidarSpatialSnapshot build(
@@ -109,7 +133,12 @@ public final class VidarSpatialSnapshot {
         boolean blocked = computeIntakeBlocked(world, foesOut);
         Pose2D fieldPose = resolveFieldPose(vision, fieldPoseSupplier);
         int tracks = world != null && world.isMotionTrackingActive() ? world.trackCount() : 0;
-        return new VidarSpatialSnapshot(elementsOut, alliesOut, foesOut, blocked, fieldPose, tracks);
+        Pose2D fused = vision == null ? null : vision.getFusedFieldPose();
+        Pose2D correctedNow = vision == null ? null : vision.getGatedTagCorrectedFieldPoseNow();
+        long correctionNanos = vision == null ? 0L : vision.lastTagCorrectionNanos();
+        return new VidarSpatialSnapshot(
+                elementsOut, alliesOut, foesOut, blocked, fieldPose, tracks,
+                fused, correctedNow, correctionNanos);
     }
 
     private static boolean computeIntakeBlocked(VidarWorldModel world, List<VidarSpatialPoint> foes) {

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarFusionEngine.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarFusionEngine.java
@@ -257,21 +257,24 @@ public final class VidarFusionEngine implements VidarVisionFusion {
             return;
         }
         Pose2D odomNow = odomSupplier.get();
-        Pose2D odomAtCapture = null;
         if (latestTag != null && latestTag.captureTimeNanos > 0) {
-            odomAtCapture = odomHistory.at(latestTag.captureTimeNanos);
+            Pose2D odomAtCapture = odomHistory.at(latestTag.captureTimeNanos);
+            if (odomAtCapture == null) {
+                // Cannot latency-compensate — keep prior fused; do not stamp odom-at-fuse.
+                fusedFieldPose = localization.lastFusedFieldPose();
+                return;
+            }
+            VidarLocalizationFusion.Result result = localization.fusedFieldPoseNow(
+                    latestTag, latestScoutObservation, odomAtCapture, odomNow);
+            fusedFieldPose = result.pose;
+            // Only stamp odom when a gate-accepted correction lands — otherwise fuse→setPose
+            // re-propagation collapses to (now - now) on the next worker tick.
+            if (result.acceptedNewCorrection) {
+                odomAtLastFusedFieldPose = odomNow;
+            }
+            return;
         }
-        if (odomAtCapture == null) {
-            odomAtCapture = odomNow;
-        }
-        Pose2D fused = localization.fusedFieldPoseNow(
-                latestTag, latestScoutObservation, odomAtCapture, odomNow);
-        if (fused != null) {
-            fusedFieldPose = fused;
-            odomAtLastFusedFieldPose = odomNow;
-        } else {
-            fusedFieldPose = localization.lastFusedFieldPose();
-        }
+        fusedFieldPose = localization.lastFusedFieldPose();
     }
 
     /**
@@ -581,9 +584,35 @@ public final class VidarFusionEngine implements VidarVisionFusion {
         return latestScoutObservation;
     }
 
-    /** Latest localization fusion result (tag + team odom). */
+    /** Latest localization fusion result (tag + team odom). Never uses external Pedro supplier. */
     public Pose2D getFusedFieldPose() {
         return fusedFieldPose;
+    }
+
+    /** {@link System#nanoTime()} when the last gate-accepted tag correction was applied (0 = none). */
+    public long lastTagCorrectionNanos() {
+        return localization.lastCorrectionNanos();
+    }
+
+    /**
+     * Gated tag fix re-propagated to the current odom sample — safe for {@code follower.setPose}.
+     *
+     * <p>Unlike {@link #getFieldPoseForMotionTracking()}, this never uses an ungated {@code latestTag}
+     * and never falls back to raw odom. Returns {@code null} until a pose gate has accepted a fix.
+     */
+    public Pose2D getGatedTagCorrectedFieldPoseNow() {
+        Pose2D anchor = localization.lastFusedFieldPose();
+        if (anchor == null) {
+            return null;
+        }
+        if (odomSupplier == null) {
+            return anchor;
+        }
+        Pose2D odomNow = odomSupplier.get();
+        if (odomNow == null || odomAtLastFusedFieldPose == null) {
+            return anchor;
+        }
+        return VidarMotionCorrection.robotFieldPoseNow(anchor, odomAtLastFusedFieldPose, odomNow);
     }
 
     /**

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarLocalizationFusion.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarLocalizationFusion.java
@@ -14,6 +14,20 @@ import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
  */
 public final class VidarLocalizationFusion {
 
+    /** Outcome of one fusion attempt. */
+    public static final class Result {
+        public final Pose2D pose;
+        /** True only when this call accepted a new gated tag correction. */
+        public final boolean acceptedNewCorrection;
+        public final long correctionNanos;
+
+        public Result(Pose2D pose, boolean acceptedNewCorrection, long correctionNanos) {
+            this.pose = pose;
+            this.acceptedNewCorrection = acceptedNewCorrection;
+            this.correctionNanos = correctionNanos;
+        }
+    }
+
     private Pose2D fieldPosePrior;
     private Pose2D lastFusedFieldPose;
     private long lastCorrectionNanos;
@@ -30,6 +44,11 @@ public final class VidarLocalizationFusion {
         return lastFusedFieldPose;
     }
 
+    /** Monotonic id of the last gate-accepted correction ({@link System#nanoTime()} at accept). */
+    public long lastCorrectionNanos() {
+        return lastCorrectionNanos;
+    }
+
     /** Clear fused pose scratch between match periods (keeps field pose prior). */
     public void resetMatchState() {
         lastFusedFieldPose = null;
@@ -38,8 +57,10 @@ public final class VidarLocalizationFusion {
 
     /**
      * Apply decoded tag correction with pose gates. Scout observations are ignored for pose fusion.
+     *
+     * @return pose + whether a <em>new</em> correction was accepted (for odom stamping)
      */
-    public Pose2D fusedFieldPoseNow(
+    public Result fusedFieldPoseNow(
             VidarTagObservation decoded,
             VidarTagScoutObservation scout,
             Pose2D odomAtCapture,
@@ -49,10 +70,10 @@ public final class VidarLocalizationFusion {
             if (passesPoseGates(decoded, candidate, odomNow)) {
                 lastFusedFieldPose = applyCorrectionLimit(candidate);
                 lastCorrectionNanos = System.nanoTime();
+                return new Result(lastFusedFieldPose, true, lastCorrectionNanos);
             }
-            return lastFusedFieldPose;
         }
-        return lastFusedFieldPose;
+        return new Result(lastFusedFieldPose, false, lastCorrectionNanos);
     }
 
     private boolean passesPoseGates(VidarTagObservation tag, Pose2D candidate, Pose2D odomNow) {
@@ -123,5 +144,4 @@ public final class VidarLocalizationFusion {
     public boolean wouldScoutAlterPose(VidarTagScoutObservation scout) {
         return false;
     }
-
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarVisionFusion.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarVisionFusion.java
@@ -18,4 +18,10 @@ public interface VidarVisionFusion {
     Pose2D getFusedFieldPose();
 
     Pose2D getFieldPoseForMotionTracking();
+
+    /** Gated tag fix re-propagated to current odom; null until a pose gate accepts a fix. */
+    Pose2D getGatedTagCorrectedFieldPoseNow();
+
+    /** {@link System#nanoTime()} of last gate-accepted correction (0 = none). */
+    long lastTagCorrectionNanos();
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroCorrectionTracker.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroCorrectionTracker.java
@@ -1,0 +1,68 @@
+package org.firstinspires.ftc.teamcode.vidar.integration;
+
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+import org.firstinspires.ftc.teamcode.vidar.fusion.VidarMotionCorrection;
+
+/**
+ * Sparse ViDAR → Pedro pose correction with latency compensation.
+ *
+ * <p><b>Why not {@code spatial.fieldPose()} alone?</b> When Pedro is wired via
+ * {@code setFieldPoseSupplier}, {@code fieldPose()} is the live Pedro pose — not the fused tag
+ * anchor. Gating novelty on that value re-fires {@code setPose} as the robot drives.
+ *
+ * <p><b>Correct chain:</b>
+ * <ol>
+ *   <li>Tag stores {@code fieldPoseAtCapture}</li>
+ *   <li>Fusion accepts a gated fix → {@code lastTagCorrectionNanos()} advances;
+ *       odom-at-fuse is stamped once</li>
+ *   <li>At setPose time: {@code tagCorrectedFieldPoseNow()} re-propagates fuse → current odom</li>
+ * </ol>
+ *
+ * <pre>{@code
+ * tracker.poll(spatial.lastTagCorrectionNanos(), spatial.tagCorrectedFieldPoseNow())
+ * }</pre>
+ */
+public final class VidarPedroCorrectionTracker {
+
+    private long lastAppliedCorrectionNanos;
+
+    public VidarPedroCorrectionTracker() {
+        this.lastAppliedCorrectionNanos = 0L;
+    }
+
+    /**
+     * Preferred entry: event-id gating (no pose epsilon, no second cooldown).
+     *
+     * @param correctionNanos {@code spatial.lastTagCorrectionNanos()} — 0 means no fix yet
+     * @param poseCorrectedToNow {@code spatial.tagCorrectedFieldPoseNow()}
+     * @return Pedro components for {@code follower.setPose}, or {@code null} to skip
+     */
+    public VidarPedroPose poll(long correctionNanos, Pose2D poseCorrectedToNow) {
+        if (correctionNanos <= 0L || poseCorrectedToNow == null) {
+            return null;
+        }
+        if (correctionNanos == lastAppliedCorrectionNanos) {
+            return null;
+        }
+        lastAppliedCorrectionNanos = correctionNanos;
+        return VidarPedroPoseBridge.fromPose2D(poseCorrectedToNow);
+    }
+
+    /**
+     * Manual backdate when you hold capture-time field pose + odom samples yourself.
+     */
+    public static Pose2D backdateToNow(
+            Pose2D fieldPoseAtCapture,
+            Pose2D odomAtCapture,
+            Pose2D odomNow) {
+        return VidarMotionCorrection.robotFieldPoseNow(fieldPoseAtCapture, odomAtCapture, odomNow);
+    }
+
+    public void reset() {
+        lastAppliedCorrectionNanos = 0L;
+    }
+
+    public long lastAppliedCorrectionNanos() {
+        return lastAppliedCorrectionNanos;
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroPose.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroPose.java
@@ -1,0 +1,39 @@
+package org.firstinspires.ftc.teamcode.vidar.integration;
+
+/**
+ * Pedro-native pose components without a Pedro Pathing classpath dependency.
+ *
+ * <p>Matches {@code com.pedropathing.geometry.Pose} conventions used by most FTC teams:
+ * field {@code x}/{@code y} in <strong>inches</strong>, heading in <strong>radians</strong>.
+ *
+ * <p>Construct a Pedro pose in team code with:
+ * <pre>{@code
+ * Pose pedro = new Pose(vidarPedro.x, vidarPedro.y, vidarPedro.headingRad);
+ * }</pre>
+ *
+ * <p>Assumes the team uses the same field origin/axes for ViDAR {@link
+ * org.firstinspires.ftc.robotcore.external.navigation.Pose2D} and Pedro. If you use Pedro
+ * coordinate-system converters, convert before/after this DTO.
+ */
+public final class VidarPedroPose {
+
+    public final double x;
+    public final double y;
+    /** Heading in radians (Pedro {@code Pose.getHeading()}). */
+    public final double headingRad;
+
+    public VidarPedroPose(double x, double y, double headingRad) {
+        this.x = x;
+        this.y = y;
+        this.headingRad = headingRad;
+    }
+
+    public double headingDeg() {
+        return Math.toDegrees(headingRad);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(%.2f, %.2f) %.1f°", x, y, headingDeg());
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroPoseBridge.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/integration/VidarPedroPoseBridge.java
@@ -1,0 +1,67 @@
+package org.firstinspires.ftc.teamcode.vidar.integration;
+
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Converts between FTC {@link Pose2D} (ViDAR) and Pedro-native components ({@link VidarPedroPose}).
+ *
+ * <p>ViDAR stores headings with {@link AngleUnit#DEGREES} on {@link Pose2D}. Pedro {@code Pose}
+ * uses radians. Positions are inches on both sides.
+ *
+ * <p>No Pedro Maven dependency is required - wrap results into {@code com.pedropathing.geometry.Pose}
+ * in team code that already depends on Pedro Pathing.
+ */
+public final class VidarPedroPoseBridge {
+
+    private VidarPedroPoseBridge() {}
+
+    public static VidarPedroPose fromPose2D(Pose2D pose) {
+        if (pose == null) {
+            return null;
+        }
+        return new VidarPedroPose(
+                pose.getX(DistanceUnit.INCH),
+                pose.getY(DistanceUnit.INCH),
+                pose.getHeading(AngleUnit.RADIANS));
+    }
+
+    public static Pose2D toPose2D(VidarPedroPose pose) {
+        if (pose == null) {
+            return null;
+        }
+        return toPose2D(pose.x, pose.y, pose.headingRad);
+    }
+
+    public static Pose2D toPose2D(double xIn, double yIn, double headingRad) {
+        return new Pose2D(DistanceUnit.INCH, xIn, yIn, AngleUnit.RADIANS, headingRad);
+    }
+
+    /**
+     * Adapts a Pedro pose supplier (inches + radians) into a ViDAR {@link Pose2D} supplier for
+     * {@link org.firstinspires.ftc.teamcode.vidar.VidarSpatial#create} odom / field priors.
+     */
+    public static Supplier<Pose2D> asPose2DSupplier(Supplier<VidarPedroPose> pedroPoseSupplier) {
+        if (pedroPoseSupplier == null) {
+            return null;
+        }
+        return () -> toPose2D(pedroPoseSupplier.get());
+    }
+
+    /**
+     * Convenience when team code already exposes Pedro {@code getX()/getY()/getHeading()} via lambdas.
+     */
+    public static Supplier<Pose2D> asPose2DSupplier(
+            DoubleSupplier xIn,
+            DoubleSupplier yIn,
+            DoubleSupplier headingRad) {
+        if (xIn == null || yIn == null || headingRad == null) {
+            return null;
+        }
+        return () -> toPose2D(xIn.getAsDouble(), yIn.getAsDouble(), headingRad.getAsDouble());
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
@@ -164,7 +164,22 @@ public final class VidarRuntime {
 
     /** Pin the latest published snapshot for one robot-loop iteration (legacy {@code update()}). */
     public VidarSpatialSnapshot pinSnapshot() {
-        return publishedSnapshot.get();
+        synchronized (this) {
+            VidarSpatialSnapshot base = publishedSnapshot.get();
+            VidarFusionEngine engine = fusionEngine;
+            if (engine == null) {
+                return base;
+            }
+            // Refresh odom + correction fields under the runtime lock so OpMode getters stay
+            // consistent for one loop and fuse→now uses the latest follower sample.
+            if (fieldPoseContext.odomSupplier() != null) {
+                engine.recordOdom(fieldPoseContext.odomSupplier().get());
+            }
+            return base.withCorrections(
+                    engine.getFusedFieldPose(),
+                    engine.getGatedTagCorrectedFieldPoseNow(),
+                    engine.lastTagCorrectionNanos());
+        }
     }
 
     public VidarCorrectedFrame updateCorrected() {


### PR DESCRIPTION
## Summary
- Optional `vidar.integration` bridge (`VidarPedroPose` / bridge / `VidarPedroCorrectionTracker`) plus sample OpMode and `docs/PEDRO_INTEGRATION.md` — no Pedro Maven dependency
- Fix sparse `setPose` wiring: gate novelty on `lastTagCorrectionNanos()`, inject `tagCorrectedFieldPoseNow()`, stamp odom-at-fuse only on accepted corrections, pin correction fields on `spatial.update()`
- java-pure tests for fusion accept/stamp semantics and tracker event-id gating

## Test plan
- [x] CI green on branch (`java-compile`, `java-pure`, ubuntu/windows `test`)
- [ ] Deploy **ViDAR: Pedro Bridge Sample**; confirm fused anchor vs corrected-now Δ and correction id telemetry
- [ ] In a Pedro project, wire per `docs/PEDRO_INTEGRATION.md` and verify `setPose` only fires on new tag corrections (not while driving)