### PR TITLE
fix mount rotation to Vitelli XYZ roll-pitch-yaw

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -166,9 +166,9 @@ Each camera mount is a position plus orientation in robot frame:
 |-------|---------|
 | `bearingDeg` | Horizontal look direction: 0 = front, 90 = right, 180 = back, 270 = left |
 | `xIn`, `yIn`, `zIn` | Lens position from robot center (+X forward, +Y left, +Z up from floor) |
-| `pitchDeg` | Inclination; **negative = looking down** (typical field view) |
-| `rollDeg` | Roll about optical axis (bumps / sideways tilt) |
-| `yawDeg` | Small twist about optical axis (usually 0) |
+| `pitchDeg` | Inclination about robot +Y; **negative = looking down** (typical field view) |
+| `rollDeg` | Bank about robot +X / optical forward |
+| `yawDeg` | Small pan about robot +Z (added to `bearingDeg`; usually 0) |
 
 Nested form is also accepted:
 

--- a/docs/COORDINATE_FRAMES.md
+++ b/docs/COORDINATE_FRAMES.md
@@ -86,15 +86,24 @@ Examples:
 
 Implementation: `teamcode/.../vidar/geometry/VidarTransform3D.java` (Python: `src/vidar/transforms.py`).
 
-### Rotation order (documented and tested)
+### Rotation order (Vitelli axes)
 
-Mount rotation uses **intrinsic** roll-pitch-yaw with multiply order:
+Mount rotation uses roll about +X, pitch about +Y, yaw about +Z (right-handed), composed as intrinsic yaw → pitch → roll so side-camera pitch still nods the lens:
 
 ```
-R = Rz(yaw) * Rx(pitch) * Rz(roll)
+R = Rz(bearing + yaw) * Ry(pitch_rh) * Rx(roll) * R_optical_to_robot_base
 ```
 
-Camera pipeline applies `Rz(bearing + mountYaw) * Rx(mountPitch) * Rz(mountRoll)` after a fixed optical-to-robot-base mapping. This matches legacy `VidarGeometry.rayDirectionRobotFrame()`.
+| Config field | Axis | Effect |
+|--------------|------|--------|
+| `rollDeg` | +X | Bank about optical forward (after base map) |
+| `pitchDeg` | +Y | Nod; **negative = looking down** (aviation sign → `pitch_rh = -pitchDeg`) |
+| `yawDeg` | +Z | Small pan offset, added to `bearingDeg` |
+| `bearingDeg` | +Z | Compass facing (0 front, 90 right, …) |
+
+`R_optical_to_robot_base` maps OpenCV optical (+X right, +Y down, +Z forward) to robot (+X forward, +Y left, +Z up) at zero mount angles.
+
+Canonical tests: `tests/test_coordinate_frames.py` (`TestMountRotationConvention`) and `java-pure/.../MountRotationConventionTest.java`.
 
 ---
 

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/geometry/MountRotationConventionTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/geometry/MountRotationConventionTest.java
@@ -1,0 +1,146 @@
+package org.firstinspires.ftc.teamcode.vidar.geometry;
+
+import org.firstinspires.ftc.teamcode.vidar.runtime.VidarCameraProfile;
+import org.firstinspires.ftc.teamcode.vidar.runtime.VidarCameraRoiConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Vitelli axes (roll +X, pitch +Y, yaw +Z) with intrinsic yaw → pitch → roll:
+ * {@code Rz(bearing+yaw) * Ry(pitch_rh) * Rx(roll) * opticalToRobotBase},
+ * with config {@code pitchDeg} aviation-signed (negative = look down).
+ */
+class MountRotationConventionTest {
+
+    private static final double EPS = 1e-6;
+
+    private static VidarCameraProfile profile(
+            double bearing, double yaw, double pitch, double roll) {
+        return new VidarCameraProfile(
+                "test",
+                bearing,
+                12,
+                340,
+                340,
+                320,
+                240,
+                70,
+                55,
+                new double[] {95},
+                new double[] {12},
+                0,
+                0,
+                9,
+                yaw,
+                pitch,
+                roll,
+                12.0,
+                VidarCameraRoiConfig.DEFAULT);
+    }
+
+    private static VidarVec3 opticalAxisInRobot(
+            VidarCameraProfile p, double ox, double oy, double oz) {
+        VidarTransformRegistry.CameraTransforms ct =
+                VidarTransformRegistry.buildForProfile(p);
+        return ct.robotTCamera.transformDirection(new VidarVec3(ox, oy, oz));
+    }
+
+    private static void assertVec(VidarVec3 v, double x, double y, double z) {
+        assertEquals(x, v.x, EPS, "x");
+        assertEquals(y, v.y, EPS, "y");
+        assertEquals(z, v.z, EPS, "z");
+    }
+
+    @Test
+    void opticalToRobotBaseMapsOpenCvAxes() {
+        VidarRotation3D r = VidarRotation3D.opticalToRobotBase();
+        assertVec(r.rotate(new VidarVec3(0, 0, 1)), 1, 0, 0);
+        assertVec(r.rotate(new VidarVec3(1, 0, 0)), 0, -1, 0);
+        assertVec(r.rotate(new VidarVec3(0, 1, 0)), 0, 0, -1);
+    }
+
+    @Test
+    void identityMountFacesForwardLevel() {
+        VidarCameraProfile p = profile(0, 0, 0, 0);
+        assertVec(opticalAxisInRobot(p, 0, 0, 1), 1, 0, 0);
+        assertVec(opticalAxisInRobot(p, 1, 0, 0), 0, -1, 0);
+        assertVec(opticalAxisInRobot(p, 0, 1, 0), 0, 0, -1);
+    }
+
+    @Test
+    void negativePitchNodsOpticalForwardDown() {
+        VidarCameraProfile p = profile(0, 0, -30, 0);
+        double s30 = Math.sin(Math.toRadians(30));
+        double c30 = Math.cos(Math.toRadians(30));
+        // pitchDeg -30 → RH pitch +30 → optical forward (+X) toward −Z
+        assertVec(opticalAxisInRobot(p, 0, 0, 1), c30, 0, -s30);
+        assertVec(opticalAxisInRobot(p, 1, 0, 0), 0, -1, 0);
+        assertVec(opticalAxisInRobot(p, 0, 1, 0), -s30, 0, -c30);
+    }
+
+    @Test
+    void rollBanksAboutOpticalForward() {
+        VidarCameraProfile p = profile(0, 0, 0, 30);
+        double s30 = Math.sin(Math.toRadians(30));
+        double c30 = Math.cos(Math.toRadians(30));
+        assertVec(opticalAxisInRobot(p, 0, 0, 1), 1, 0, 0);
+        assertVec(opticalAxisInRobot(p, 1, 0, 0), 0, -c30, -s30);
+        assertVec(opticalAxisInRobot(p, 0, 1, 0), 0, s30, -c30);
+    }
+
+    @Test
+    void yawAndBearingPanAboutVertical() {
+        VidarCameraProfile byYaw = profile(0, 30, 0, 0);
+        VidarCameraProfile byBearing = profile(30, 0, 0, 0);
+        double s30 = Math.sin(Math.toRadians(30));
+        double c30 = Math.cos(Math.toRadians(30));
+        assertVec(opticalAxisInRobot(byYaw, 0, 0, 1), c30, s30, 0);
+        assertVec(opticalAxisInRobot(byBearing, 0, 0, 1), c30, s30, 0);
+    }
+
+    @Test
+    void rollAndYawAreIndependentAxes() {
+        VidarVec3 afterRoll = opticalAxisInRobot(profile(0, 0, 0, 30), 0, 0, 1);
+        VidarVec3 afterYaw = opticalAxisInRobot(profile(0, 30, 0, 0), 0, 0, 1);
+        assertEquals(1.0, afterRoll.x, EPS);
+        assertTrue(Math.abs(afterYaw.y) > 0.4);
+        assertNotEquals(afterRoll.y, afterYaw.y, 0.1);
+    }
+
+    @Test
+    void bearing90FacesRobotPositiveY() {
+        VidarCameraProfile p = profile(90, 0, 0, 0);
+        assertVec(opticalAxisInRobot(p, 0, 0, 1), 0, 1, 0);
+        assertVec(opticalAxisInRobot(p, 1, 0, 0), 1, 0, 0);
+        assertVec(opticalAxisInRobot(p, 0, 1, 0), 0, 0, -1);
+    }
+
+    @Test
+    void bearing90WithPitchDownTiltsIntoFloor() {
+        VidarCameraProfile p = profile(90, 0, -30, 0);
+        double s30 = Math.sin(Math.toRadians(30));
+        double c30 = Math.cos(Math.toRadians(30));
+        // Yaw 90 then pitch: forward was +Y, pitch about Y moves it toward −Z
+        assertVec(opticalAxisInRobot(p, 0, 0, 1), 0, c30, -s30);
+    }
+
+    @Test
+    void fromRollPitchYawIsVitelliXyz() {
+        VidarRotation3D r = VidarRotation3D.fromRollPitchYawDeg(10, -20, 30);
+        VidarRotation3D expected = VidarRotation3D.rotateZ(Math.toRadians(30))
+                .times(VidarRotation3D.rotateY(Math.toRadians(-20)))
+                .times(VidarRotation3D.rotateX(Math.toRadians(10)));
+        for (int i = 0; i < 9; i++) {
+            assertEquals(expected.m[i], r.m[i], EPS, "m[" + i + "]");
+        }
+    }
+
+    @Test
+    void defaultConfigPitchDepressesOpticalAxis() {
+        VidarCameraProfile p = profile(0, 0, -12, 0);
+        VidarVec3 forward = opticalAxisInRobot(p, 0, 0, 1);
+        assertTrue(forward.z < -0.15, "pitchDeg -12 must depress optical forward");
+        assertEquals(0.0, forward.y, EPS);
+    }
+}

--- a/src/vidar/transforms.py
+++ b/src/vidar/transforms.py
@@ -65,6 +65,11 @@ def _rotate_x(rad: float) -> tuple[float, ...]:
     return (1, 0, 0, 0, c, -s, 0, s, c)
 
 
+def _rotate_y(rad: float) -> tuple[float, ...]:
+    c, s = math.cos(rad), math.sin(rad)
+    return (c, 0, s, 0, 1, 0, -s, 0, c)
+
+
 def _rotate_z(rad: float) -> tuple[float, ...]:
     c, s = math.cos(rad), math.sin(rad)
     return (c, -s, 0, s, c, 0, 0, 0, 1)
@@ -84,8 +89,9 @@ class Rotation3D:
 
     @staticmethod
     def from_roll_pitch_yaw_deg(roll_deg: float, pitch_deg: float, yaw_deg: float) -> Rotation3D:
-        r_roll = _rotate_z(math.radians(roll_deg))
-        r_pitch = _rotate_x(math.radians(pitch_deg))
+        """Vitelli axes: R = Rz(yaw) * Ry(pitch) * Rx(roll). Positive pitch looks down (+X→−Z)."""
+        r_roll = _rotate_x(math.radians(roll_deg))
+        r_pitch = _rotate_y(math.radians(pitch_deg))
         r_yaw = _rotate_z(math.radians(yaw_deg))
         return Rotation3D(_mat3_mul(_mat3_mul(r_yaw, r_pitch), r_roll))
 
@@ -275,10 +281,11 @@ class CameraTransforms:
 
 
 def build_robot_t_camera(profile: CameraProfile) -> CameraTransforms:
-    mount_rot = (
-        Rotation3D(_rotate_z(math.radians(profile.bearing_deg + profile.mount_yaw_deg)))
-        .times(Rotation3D(_rotate_x(math.radians(profile.mount_pitch_deg))))
-        .times(Rotation3D(_rotate_z(math.radians(profile.mount_roll_deg))))
+    # Config pitchDeg: negative = look down. Vitelli/RH pitch: positive = look down.
+    mount_rot = Rotation3D.from_roll_pitch_yaw_deg(
+        profile.mount_roll_deg,
+        -profile.mount_pitch_deg,
+        profile.bearing_deg + profile.mount_yaw_deg,
     )
     rot = mount_rot.times(Rotation3D(optical_to_robot_base()))
     trans = Vec3(profile.mount_x, profile.mount_y, profile.mount_z)

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/geometry/VidarRotation3D.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/geometry/VidarRotation3D.java
@@ -3,11 +3,14 @@ package org.firstinspires.ftc.teamcode.vidar.geometry;
 /**
  * 3D rotation stored as an orthonormal 3×3 matrix (row-major, no heap allocs after construction).
  *
- * <p>ViDAR uses <b>intrinsic</b> roll-pitch-yaw about fixed body axes in this multiply order:
- * {@code R = Rz(yaw) * Rx(pitch) * Rz(roll)} applied as {@code v_out = R * v_in}.
+ * <p>Mount / body orientation uses Vitelli axes — roll about +X, pitch about +Y, yaw about +Z —
+ * with intrinsic yaw-then-pitch-then-roll composition:
+ * {@code R = Rz(yaw) * Ry(pitch) * Rx(roll)} applied as {@code v_out = R * v_in}.
+ * That keeps "pitch down" meaningful after a non-zero bearing (side cameras).
  *
- * <p>Camera mount rotations compose on top of a fixed optical-to-robot-base mapping; see
- * {@link VidarTransformRegistry}.
+ * <p>Camera mounts compose that rotation on top of {@link #opticalToRobotBase()}; see
+ * {@link VidarTransformRegistry}. Config {@code pitchDeg} uses aviation sign
+ * (negative = look down); the registry converts to right-handed pitch.
  */
 public final class VidarRotation3D {
 
@@ -27,12 +30,13 @@ public final class VidarRotation3D {
     }
 
     /**
-     * Intrinsic roll (about +Z), pitch (about +X), yaw (about +Z) in degrees.
-     * Multiply order: {@code Rz(yaw) * Rx(pitch) * Rz(roll)}.
+     * Roll-pitch-yaw in degrees about robot +X / +Y / +Z (right-handed).
+     * Multiply order: {@code Rz(yaw) * Ry(pitch) * Rx(roll)} (intrinsic yaw → pitch → roll).
+     * Positive pitch about +Y moves robot +X toward −Z (look down).
      */
     public static VidarRotation3D fromRollPitchYawDeg(double rollDeg, double pitchDeg, double yawDeg) {
-        VidarRotation3D rRoll = rotateZ(Math.toRadians(rollDeg));
-        VidarRotation3D rPitch = rotateX(Math.toRadians(pitchDeg));
+        VidarRotation3D rRoll = rotateX(Math.toRadians(rollDeg));
+        VidarRotation3D rPitch = rotateY(Math.toRadians(pitchDeg));
         VidarRotation3D rYaw = rotateZ(Math.toRadians(yawDeg));
         return rYaw.times(rPitch).times(rRoll);
     }
@@ -44,6 +48,16 @@ public final class VidarRotation3D {
                 1, 0, 0,
                 0, c, -s,
                 0, s, c
+        });
+    }
+
+    public static VidarRotation3D rotateY(double rad) {
+        double c = Math.cos(rad);
+        double s = Math.sin(rad);
+        return new VidarRotation3D(new double[] {
+                c, 0, s,
+                0, 1, 0,
+                -s, 0, c
         });
     }
 

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/geometry/VidarTransformRegistry.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/geometry/VidarTransformRegistry.java
@@ -77,19 +77,22 @@ public final class VidarTransformRegistry {
     }
 
     /**
-     * Builds {@code robot_T_cameraOptical} matching legacy {@link org.firstinspires.ftc.teamcode.vidar.VidarGeometry#rayDirectionRobotFrame}.
+     * Builds {@code robot_T_cameraOptical} from mount extrinsics.
      *
-     * <p>Rotation chain on optical axes: {@code Rz(bearing+yaw) * Rx(pitch) * Rz(roll) * R_optical_base}.
+     * <p>{@code Rz(bearing+yaw) * Ry(pitch_rh) * Rx(roll) * R_optical_base}, with Vitelli axes
+     * (roll +X, pitch +Y, yaw +Z). Config {@code pitchDeg} is aviation-signed
+     * (negative = look down) so {@code pitch_rh = -pitchDeg}.
      */
     public static CameraTransforms buildForProfile(
             VidarCameraProfile profile, int frameWidth, int frameHeight) {
         if (profile == null) {
             return null;
         }
-        VidarRotation3D mountRot = VidarRotation3D.rotateZ(
-                        Math.toRadians(profile.bearingDeg + profile.mountYawDeg))
-                .times(VidarRotation3D.rotateX(Math.toRadians(profile.mountPitchDeg)))
-                .times(VidarRotation3D.rotateZ(Math.toRadians(profile.mountRollDeg)));
+        // Config pitchDeg: negative = look down. Vitelli/RH pitch: positive = look down.
+        VidarRotation3D mountRot = VidarRotation3D.fromRollPitchYawDeg(
+                profile.mountRollDeg,
+                -profile.mountPitchDeg,
+                profile.bearingDeg + profile.mountYawDeg);
         VidarRotation3D rot = mountRot.times(VidarRotation3D.opticalToRobotBase());
         VidarVec3 trans = new VidarVec3(profile.mountX, profile.mountY, profile.mountZ);
         VidarTransform3D robotTCamera = new VidarTransform3D(

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarCameraProfile.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarCameraProfile.java
@@ -31,7 +31,11 @@ public final class VidarCameraProfile {
     public final double mountX;
     public final double mountY;
     public final double mountZ;
-    /** Mount orientation: yaw about optical axis, pitch (negative = inclined down), roll. */
+    /**
+     * Mount orientation (degrees) in robot frame after optical→robot base.
+     * Vitelli XYZ: roll about +X, pitch about +Y, yaw about +Z (with {@code bearingDeg}).
+     * {@code mountPitchDeg} is aviation-signed: <b>negative = looking down</b>.
+     */
     public final double mountYawDeg;
     public final double mountPitchDeg;
     public final double mountRollDeg;

--- a/tests/test_coordinate_frames.py
+++ b/tests/test_coordinate_frames.py
@@ -28,6 +28,9 @@ from vidar.transforms import (
     intersect_ground_plane,
     optical_to_robot_base,
     ray_direction_robot_frame,
+    _rotate_x,
+    _rotate_y,
+    _rotate_z,
 )
 from vidar.geometry import ray_direction_robot_frame as legacy_ray  # noqa: F401 — import side test
 
@@ -243,3 +246,111 @@ class TestPropertyLoops:
         assert abs(back.x - v.x) < 1e-6
         assert abs(back.y - v.y) < 1e-6
         assert abs(back.z - v.z) < 1e-6
+
+
+def _mount_profile(
+    *,
+    bearing: float = 0.0,
+    yaw: float = 0.0,
+    pitch: float = 0.0,
+    roll: float = 0.0,
+) -> CameraProfile:
+    return CameraProfile(
+        name="test",
+        bearing_deg=bearing,
+        horizon_row_px=12,
+        focal_length_px=340,
+        floor_cy_px=(95,),
+        floor_dist=(12,),
+        mount_x=0.0,
+        mount_y=0.0,
+        mount_z=9.0,
+        mount_yaw_deg=yaw,
+        mount_pitch_deg=pitch,
+        mount_roll_deg=roll,
+        calibration_width=640,
+        calibration_height=480,
+    )
+
+
+def _optical_axes(profile: CameraProfile) -> tuple[Vec3, Vec3, Vec3]:
+    ct = build_robot_t_camera(profile)
+    r = ct.robot_t_camera.rotation
+    return (
+        r.rotate(Vec3(0, 0, 1)),  # optical forward
+        r.rotate(Vec3(1, 0, 0)),  # optical right
+        r.rotate(Vec3(0, 1, 0)),  # optical down
+    )
+
+
+def _approx_vec(v: Vec3, xyz: tuple[float, float, float]) -> None:
+    assert (v.x, v.y, v.z) == pytest.approx(xyz, abs=1e-9)
+
+
+class TestMountRotationConvention:
+    """Vitelli axes: Rz(yaw)*Ry(pitch)*Rx(roll); config pitch negative = look down."""
+
+    def test_optical_to_robot_base(self):
+        r = Rotation3D(optical_to_robot_base())
+        _approx_vec(r.rotate(Vec3(0, 0, 1)), (1, 0, 0))
+        _approx_vec(r.rotate(Vec3(1, 0, 0)), (0, -1, 0))
+        _approx_vec(r.rotate(Vec3(0, 1, 0)), (0, 0, -1))
+
+    def test_identity_mount_level_forward(self):
+        fwd, right, down = _optical_axes(_mount_profile())
+        _approx_vec(fwd, (1, 0, 0))
+        _approx_vec(right, (0, -1, 0))
+        _approx_vec(down, (0, 0, -1))
+
+    def test_negative_pitch_nods_forward_down(self):
+        fwd, right, down = _optical_axes(_mount_profile(pitch=-30))
+        s30, c30 = math.sin(math.radians(30)), math.cos(math.radians(30))
+        _approx_vec(fwd, (c30, 0, -s30))
+        _approx_vec(right, (0, -1, 0))
+        _approx_vec(down, (-s30, 0, -c30))
+
+    def test_roll_banks_about_optical_forward(self):
+        fwd, right, down = _optical_axes(_mount_profile(roll=30))
+        s30, c30 = math.sin(math.radians(30)), math.cos(math.radians(30))
+        _approx_vec(fwd, (1, 0, 0))
+        _approx_vec(right, (0, -c30, -s30))
+        _approx_vec(down, (0, s30, -c30))
+
+    def test_yaw_and_bearing_pan_about_vertical(self):
+        fwd_yaw, _, _ = _optical_axes(_mount_profile(yaw=30))
+        fwd_bearing, _, _ = _optical_axes(_mount_profile(bearing=30))
+        s30, c30 = math.sin(math.radians(30)), math.cos(math.radians(30))
+        _approx_vec(fwd_yaw, (c30, s30, 0))
+        _approx_vec(fwd_bearing, (c30, s30, 0))
+
+    def test_roll_and_yaw_are_independent(self):
+        fwd_roll, _, _ = _optical_axes(_mount_profile(roll=30))
+        fwd_yaw, _, _ = _optical_axes(_mount_profile(yaw=30))
+        assert fwd_roll.x == pytest.approx(1.0)
+        assert abs(fwd_yaw.y) > 0.4
+        assert abs(fwd_roll.y - fwd_yaw.y) > 0.1
+
+    def test_bearing_90_faces_plus_y(self):
+        fwd, right, down = _optical_axes(_mount_profile(bearing=90))
+        _approx_vec(fwd, (0, 1, 0))
+        _approx_vec(right, (1, 0, 0))
+        _approx_vec(down, (0, 0, -1))
+
+    def test_bearing_90_with_pitch_down(self):
+        fwd, _, _ = _optical_axes(_mount_profile(bearing=90, pitch=-30))
+        s30, c30 = math.sin(math.radians(30)), math.cos(math.radians(30))
+        _approx_vec(fwd, (0, c30, -s30))
+
+    def test_default_minus_12_pitch_depresses_forward(self):
+        fwd, _, _ = _optical_axes(_mount_profile(pitch=-12))
+        assert fwd.z < -0.15
+        assert fwd.y == pytest.approx(0.0)
+
+    def test_from_roll_pitch_yaw_is_vitelli_xyz(self):
+        r = Rotation3D.from_roll_pitch_yaw_deg(10, -20, 30)
+        expected = (
+            Rotation3D(_rotate_z(math.radians(30)))
+            .times(Rotation3D(_rotate_y(math.radians(-20))))
+            .times(Rotation3D(_rotate_x(math.radians(10))))
+        )
+        assert r.m == pytest.approx(expected.m)


### PR DESCRIPTION
﻿## Summary
- Fix camera mount rotation to Vitelli axes: roll about +X, pitch about +Y, yaw about +Z
- Composition: `Rz(bearing+yaw) * Ry(pitch_rh) * Rx(roll) * R_optical_base` (intrinsic yaw → pitch → roll so side cameras still nod)
- Keep config `pitchDeg` aviation-signed (negative = look down) via `pitch_rh = -pitchDeg`
- Add Java + Python canonical mount-axis tests; update COORDINATE_FRAMES / CONFIGURATION docs

Previously roll and yaw both used `Rz` (ZXZ), so `pitchDeg: -12` banked about the view axis instead of tilting the lens down.

## Test plan
- [x] `python -m pytest tests/test_coordinate_frames.py`
- [x] `cd java-pure && ./gradlew.bat test --tests MountRotationConventionTest`
- [ ] Sim: Calibration axes overlay — confirm `pitchDeg: -12` nods optical forward down
- [ ] On robot: spot-check ground-plane / Discover ranging after the rotation change

## Follow-ups (issues)
- #13 Geometry-authoritative range fusion
- #14 Estimated vs calibrated intrinsics metadata
- #16 Calibration visualization as correctness tool
- #15 Offline Ceres optimizer (later)
