### PR TITLE
Prefer ground-plane range over heuristic averaging

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -84,9 +84,9 @@ rejected(source, reason): RangeEstimate
 distance: float
 uncertainty: float
 confidence: float       // 0–1
-source0: RangeEstimate | null
-source1: RangeEstimate | null
-sourceCount: int        // 0–2 valid slots used
+source0: RangeEstimate | null   // telemetry slot (typically GROUND_PLANE when valid)
+source1: RangeEstimate | null   // telemetry slot (best heuristic, if any)
+sourceCount: int        // 0–3 valid contributing estimates (clamped; slots still only store two)
 
 isValid(): bool         // distance > 0 && confidence > 0
 invalid(): RangeResult

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,12 +94,15 @@ sourceDistance(source: RangeSource): float
 sourceWeight(source: RangeSource): float
 ```
 
-**Fusion** (up to three estimates for elements: SIZE + FLOOR LUT + GROUND_PLANE, no list allocation):
+**Fusion** (elements: SIZE + FLOOR LUT + GROUND_PLANE; plates: WIDTH + FLOOR + GROUND_PLANE):
 
 ```
 fuseRangeWeighted(maxRangeMismatchRatio, ...estimates): RangeResult
-fusedDistance = Σ(weight × distance) / Σ(weight)
 ```
+
+- When `GROUND_PLANE` is valid, **fused distance = ground-plane distance** (projective geometry is authoritative).
+- Heuristics that agree raise confidence; heuristics that disagree lower confidence — they do **not** pull the range toward a midpoint.
+- Without a valid ground-plane estimate, inverse-variance weighting among heuristics (legacy path).
 
 Default `maxRangeMismatchRatio = 0.28`.
 

--- a/docs/COORDINATE_FRAMES.md
+++ b/docs/COORDINATE_FRAMES.md
@@ -173,7 +173,9 @@ ViDAR uses the SDK pose directly in `VidarTagObservation.fieldPoseAtCapture`. `V
 
 ## Ground-plane intersection
 
-For floor-contact targets, `VidarGroundPlane` intersects a camera ray with **z = 0** in robot frame (plates) or **z = diameter/2** for ball-center element fusion. Rejects parallel rays and rays pointing away from the floor. `VidarGeometry.floorPointInRobot()` uses `robot_T_camera` on the primary path; floor LUT remains a fusion fallback.
+For floor-contact targets, `VidarGroundPlane` intersects a camera ray with **z = 0** in robot frame (plates) or **z = diameter/2** for ball-center element fusion. Rejects parallel rays and rays pointing away from the floor. `VidarGeometry.floorPointInRobot()` uses `robot_T_camera` on the primary path.
+
+**Range fusion:** when the ground-plane estimate is valid, its slant range is **authoritative**. Size / floor LUT / plate-width estimates are cross-checks (raise or lower confidence) or fallbacks when geometry is rejected — they are not equal votes that average away from geometry.
 
 ---
 

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -124,9 +124,7 @@ Floor LUT used only as secondary consistency check when geometry supports it.
 
 ## Range fusion — **Implemented**, **Tested in simulation**
 
-`VidarRangeResult` with uncertainty-weighted fusion (up to **three** estimates: elements = SIZE + FLOOR + GROUND_PLANE; plates = width + floor + ground @ z=0):
-
-`fusedDistance = Σ(weight × distance) / Σ(weight)`
+`VidarRangeResult` with geometry-authoritative fusion (elements = SIZE + FLOOR + GROUND_PLANE; plates = width + floor + ground @ z=0). Valid ground-plane range wins the distance; heuristics cross-check confidence or fill in when geometry is rejected.
 
 Component estimates exposed as `source0`, `source1`, and `sourceCount` (up to 3) for telemetry. **ViDAR: Discover** logs `size` / `floor` / `ground` on the element detail line.
 

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/geometry/RangeFusionTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/geometry/RangeFusionTest.java
@@ -48,7 +48,39 @@ class RangeFusionTest {
         VidarRangeResult result = VidarRangeFusion.fuseRangeWeighted(size, floor, ground);
         assertTrue(result.isValid());
         assertEquals(3, result.sourceCount);
-        assertTrue(result.distance > 23 && result.distance < 26);
+        assertEquals(24.5, result.distance, 1e-9);
+        assertTrue(result.confidence > 0.7);
+        assertEquals(VidarRangeEstimate.Source.GROUND_PLANE, result.source0.source);
+    }
+
+    @Test
+    void geometryDisagreementKeepsGroundDistance() {
+        VidarRangeEstimate size = VidarRangeFusion.buildSizeEstimate(23, 20, 0.9, false, false);
+        VidarRangeEstimate floor = VidarRangeFusion.buildFloorEstimate(23, 60, 0.8, false);
+        VidarRangeEstimate ground = VidarRangeFusion.buildGroundPlaneEstimate(42, 200, 0.8, false);
+        VidarRangeResult result = VidarRangeFusion.fuseRangeWeighted(size, floor, ground);
+        assertTrue(result.isValid());
+        assertEquals(42.0, result.distance, 1e-9);
+        assertTrue(result.confidence < 0.5);
+        assertTrue(result.distance > 35);
+    }
+
+    @Test
+    void geometryOnlyUsesGroundPlane() {
+        VidarRangeEstimate ground = VidarRangeFusion.buildGroundPlaneEstimate(36, 200, 0.8, false);
+        VidarRangeResult result = VidarRangeFusion.fuseRangeWeighted(ground);
+        assertTrue(result.isValid());
+        assertEquals(36.0, result.distance, 1e-9);
+        assertEquals(VidarRangeEstimate.Source.GROUND_PLANE, result.source0.source);
+    }
+
+    @Test
+    void heuristicsOnlyStillWeighted() {
+        VidarRangeEstimate size = VidarRangeFusion.buildSizeEstimate(36, 20, 0.9, false, false);
+        VidarRangeEstimate floor = VidarRangeFusion.buildFloorEstimate(38, 60, 0.8, false);
+        VidarRangeResult result = VidarRangeFusion.fuseRangeWeighted(size, floor);
+        assertTrue(result.isValid());
+        assertTrue(result.distance > 34 && result.distance < 40);
     }
 
     @Test

--- a/src/vidar/geometry.py
+++ b/src/vidar/geometry.py
@@ -208,6 +208,7 @@ def fuse_range_weighted(
     *estimates: RangeEstimate | None,
     max_range_mismatch_ratio: float = MAX_RANGE_MISMATCH_RATIO,
 ) -> RangeResult:
+    """Ground-plane range is authoritative when valid; heuristics cross-check or fall back."""
     valid: list[RangeEstimate] = []
     first_any: RangeEstimate | None = None
     second_any: RangeEstimate | None = None
@@ -222,7 +223,7 @@ def fuse_range_weighted(
         elif any_count == 1:
             second_any = est
             any_count = 2
-        if est.is_valid and len(valid) < 3:
+        if est.is_valid and len(valid) < 4:
             valid.append(est)
 
     if not valid:
@@ -232,6 +233,56 @@ def fuse_range_weighted(
             return RangeResult(float("nan"), float("nan"), 0.0, first_any, None, 1)
         return RangeResult(float("nan"), float("nan"), 0.0, first_any, second_any, 2)
 
+    ground = next((e for e in valid if e.source == RangeSource.GROUND_PLANE), None)
+    heuristics = [e for e in valid if e.source != RangeSource.GROUND_PLANE]
+    if ground is not None:
+        return _fuse_geometry_primary(ground, heuristics, max_range_mismatch_ratio)
+    return _fuse_heuristics_weighted(valid, max_range_mismatch_ratio)
+
+
+def _fuse_geometry_primary(
+    ground: RangeEstimate,
+    heuristics: list[RangeEstimate],
+    max_range_mismatch_ratio: float,
+) -> RangeResult:
+    max_diff_vs_ground = 0.0
+    agree_count = 0
+    disagree_count = 0
+    best_heuristic: RangeEstimate | None = None
+    for h in heuristics:
+        denom = max(ground.distance, h.distance)
+        rel = abs(ground.distance - h.distance) / denom if denom > 0 else 0.0
+        max_diff_vs_ground = max(max_diff_vs_ground, rel)
+        if rel <= max_range_mismatch_ratio:
+            agree_count += 1
+        else:
+            disagree_count += 1
+        if best_heuristic is None or h.weight > best_heuristic.weight:
+            best_heuristic = h
+
+    uncertainty = ground.uncertainty
+    if not heuristics:
+        confidence = min(0.75, max(0.35, 0.55 * min(1.0, ground.weight)))
+    elif disagree_count > 0 and max_diff_vs_ground > max_range_mismatch_ratio:
+        confidence = max(0.15, 0.7 * (1.0 - max_diff_vs_ground))
+        uncertainty = ground.uncertainty * (1.0 + max_diff_vs_ground)
+    else:
+        confidence = min(1.0, 0.65 + 0.12 * agree_count)
+
+    return RangeResult(
+        ground.distance,
+        uncertainty,
+        confidence,
+        ground,
+        best_heuristic,
+        1 + len(heuristics),
+    )
+
+
+def _fuse_heuristics_weighted(
+    valid: list[RangeEstimate],
+    max_range_mismatch_ratio: float,
+) -> RangeResult:
     weight_sum = sum(e.weight for e in valid)
     weighted_dist = sum(e.weight * e.distance for e in valid)
     variance_sum = sum(e.weight * e.uncertainty * e.uncertainty for e in valid)

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/geometry/VidarRangeFusion.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/geometry/VidarRangeFusion.java
@@ -5,7 +5,8 @@ import org.firstinspires.ftc.teamcode.vidar.model.VidarRangeEstimate;
 import org.firstinspires.ftc.teamcode.vidar.model.VidarRangeResult;
 
 /**
- * Uncertainty-weighted range fusion and per-source estimate builders.
+ * Range fusion: projective ground-plane geometry is authoritative when valid;
+ * size / floor LUT / plate-width are cross-checks and fallbacks.
  */
 public final class VidarRangeFusion {
 
@@ -104,9 +105,14 @@ public final class VidarRangeFusion {
         return fuseRangeWeighted(VidarConfig.MAX_RANGE_MISMATCH_RATIO, estimates);
     }
 
+    /**
+     * When {@link VidarRangeEstimate.Source#GROUND_PLANE} is valid, its distance is authoritative.
+     * Heuristics that disagree lower confidence instead of pulling the fused range toward a midpoint.
+     * Without a valid ground-plane estimate, falls back to inverse-variance weighting among heuristics.
+     */
     public static VidarRangeResult fuseRangeWeighted(
             double maxRangeMismatchRatio, VidarRangeEstimate... estimates) {
-        VidarRangeEstimate[] valid = new VidarRangeEstimate[3];
+        VidarRangeEstimate[] valid = new VidarRangeEstimate[4];
         VidarRangeEstimate firstAny = null;
         VidarRangeEstimate secondAny = null;
         int validCount = 0;
@@ -141,6 +147,74 @@ public final class VidarRangeFusion {
             return new VidarRangeResult(Double.NaN, Double.NaN, 0, firstAny, secondAny, 2);
         }
 
+        VidarRangeEstimate ground = null;
+        VidarRangeEstimate[] heuristics = new VidarRangeEstimate[4];
+        int heuristicCount = 0;
+        for (int i = 0; i < validCount; i++) {
+            VidarRangeEstimate est = valid[i];
+            if (est.source == VidarRangeEstimate.Source.GROUND_PLANE) {
+                ground = est;
+            } else if (heuristicCount < heuristics.length) {
+                heuristics[heuristicCount++] = est;
+            }
+        }
+
+        if (ground != null) {
+            return fuseGeometryPrimary(ground, heuristics, heuristicCount, maxRangeMismatchRatio);
+        }
+        return fuseHeuristicsWeighted(valid, validCount, maxRangeMismatchRatio);
+    }
+
+    private static VidarRangeResult fuseGeometryPrimary(
+            VidarRangeEstimate ground,
+            VidarRangeEstimate[] heuristics,
+            int heuristicCount,
+            double maxRangeMismatchRatio) {
+        double maxDiffVsGround = 0;
+        int agreeCount = 0;
+        int disagreeCount = 0;
+        VidarRangeEstimate bestHeuristic = null;
+        for (int i = 0; i < heuristicCount; i++) {
+            VidarRangeEstimate h = heuristics[i];
+            double denom = Math.max(ground.distance, h.distance);
+            double rel = denom > 0 ? Math.abs(ground.distance - h.distance) / denom : 0;
+            maxDiffVsGround = Math.max(maxDiffVsGround, rel);
+            if (rel <= maxRangeMismatchRatio) {
+                agreeCount++;
+            } else {
+                disagreeCount++;
+            }
+            if (bestHeuristic == null || h.weight > bestHeuristic.weight) {
+                bestHeuristic = h;
+            }
+        }
+
+        double confidence;
+        double uncertainty = ground.uncertainty;
+        if (heuristicCount == 0) {
+            confidence = Math.min(0.75, Math.max(0.35, 0.55 * Math.min(1.0, ground.weight)));
+        } else if (disagreeCount > 0 && maxDiffVsGround > maxRangeMismatchRatio) {
+            // Keep geometry distance; do not average toward bad heuristics.
+            confidence = Math.max(0.15, 0.7 * (1.0 - maxDiffVsGround));
+            uncertainty = ground.uncertainty * (1.0 + maxDiffVsGround);
+        } else {
+            // Cross-checks agree — geometry remains the range; confidence rises with support.
+            confidence = Math.min(1.0, 0.65 + 0.12 * agreeCount);
+        }
+
+        return new VidarRangeResult(
+                ground.distance,
+                uncertainty,
+                confidence,
+                ground,
+                bestHeuristic,
+                1 + heuristicCount);
+    }
+
+    private static VidarRangeResult fuseHeuristicsWeighted(
+            VidarRangeEstimate[] valid,
+            int validCount,
+            double maxRangeMismatchRatio) {
         double weightSum = 0;
         double weightedDist = 0;
         double varianceSum = 0;

--- a/tests/test_vidar_core.py
+++ b/tests/test_vidar_core.py
@@ -6,6 +6,8 @@ import math
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tests" / "pure"))
 
@@ -64,8 +66,26 @@ class TestRangeFusion:
         result = fuse_range_weighted(size, floor, ground)
         assert result.is_valid
         assert result.source_count == 3
-        assert 23 < result.distance < 26
-        assert result.confidence > 0
+        assert result.distance == pytest.approx(24.5)
+        assert result.confidence > 0.7
+        assert result.source0.source.value == "GROUND_PLANE"
+
+    def test_geometry_disagreement_keeps_ground_distance(self):
+        size = build_size_estimate(23, 20, 0.9, False, False)
+        floor = build_floor_estimate(23, 60, 0.8, False)
+        ground = build_ground_plane_estimate(42, 200, 0.8, False)
+        result = fuse_range_weighted(size, floor, ground)
+        assert result.is_valid
+        assert result.distance == pytest.approx(42.0)
+        assert result.confidence < 0.5
+        assert result.distance > 35
+
+    def test_geometry_only_uses_ground_plane(self):
+        ground = build_ground_plane_estimate(36, 200, 0.8, False)
+        result = fuse_range_weighted(ground)
+        assert result.is_valid
+        assert result.distance == pytest.approx(36.0)
+        assert result.source0.source.value == "GROUND_PLANE"
 
     def test_ground_plane_range_with_mount(self):
         profile = CameraProfile(


### PR DESCRIPTION
﻿## Summary
- When `GROUND_PLANE` is valid, fused distance equals the geometric slant range (not a peer average with size/LUT)
- Heuristics that agree raise confidence; heuristics that disagree lower confidence without moving the range
- Without ground plane, keep inverse-variance weighting among size/floor/plate-width
- Java + Python parity; docs updated (`API`, `COORDINATE_FRAMES`, `SYSTEM_DESIGN`)

Fixes #13

## Test plan
- [x] `python -m pytest tests/test_vidar_core.py tests/test_coordinate_frames.py`
- [x] `cd java-pure && ./gradlew.bat test --tests RangeFusionTest`
- [ ] Discover telemetry: size/floor/ground still shown; fused stays near ground when they disagree
