### PR TITLE
Surface observation-worker failures in diagnostics

### DIFF
--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -52,7 +52,7 @@ flowchart TB
 | VisionPortal callback | Publish frame to mailbox only |
 | `VidarGlobalVisionWorker` | Round-robin async contour/tag scout processing |
 | `VidarTagDecodeWorker` | Async AprilTag crop decode (≤ 1/s) |
-| `VidarObservationWorker` | Poll cameras, fuse, update world model, publish snapshots |
+| `VidarObservationWorker` | Poll cameras, fuse, update world model, publish snapshots. Tick failures are recorded (last error, consecutive/total counts) and visible in `VidarDiagnostics`; the worker stays alive. |
 | Robot / OpMode loop | Read immutable `snapshot()` — never advances perception |
 
 **FTC lifecycle (Auto → TeleOp):**

--- a/docs/TEACHING.md
+++ b/docs/TEACHING.md
@@ -125,3 +125,7 @@ Multi-camera is configured, not hand-wired in the OpMode. Prefer:
 Do **not** construct a second `VidarVision` in team OpModes for multi-cam; that bypasses fusion and the runtime/attachment split.
 
 See [ROADMAP.md](ROADMAP.md) for USB hub wiring and validation checklist.
+
+## Troubleshooting
+
+If **ViDAR: Discover** shows `Worker failures=…`, the background observation tick threw. Snapshots may be stale; the worker stays alive and does not restart cameras — read the last error on that telemetry line.

--- a/java-pure/build.gradle
+++ b/java-pure/build.gradle
@@ -58,7 +58,6 @@ sourceSets {
             exclude 'runtime/CameraPipelineConfig.java'
             exclude 'runtime/VidarRuntime.java'
             exclude 'runtime/VidarVisionAttachment.java'
-            exclude 'runtime/VidarObservationWorker.java'
             exclude 'runtime/RuntimeBootstrap.java'
             exclude 'runtime/VidarMetrics.java'
             exclude 'runtime/VidarMetricsLogger.java'

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/runtime/ObservationWorkerTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/runtime/ObservationWorkerTest.java
@@ -1,0 +1,63 @@
+package org.firstinspires.ftc.teamcode.vidar.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObservationWorkerTest {
+
+    @Test
+    void recordsFailureThenResetsConsecutiveOnSuccess() {
+        VidarObservationWorker worker = new VidarObservationWorker(() -> { });
+        worker.onTickFailure(new RuntimeException("boom"));
+
+        assertEquals(1, worker.consecutiveFailureCount());
+        assertEquals(1, worker.totalFailureCount());
+        assertTrue(worker.lastErrorMessage().contains("boom"));
+        assertTrue(worker.lastErrorMessage().length() <= VidarObservationWorker.MAX_ERROR_CHARS);
+
+        worker.onTickSuccess();
+        assertEquals(0, worker.consecutiveFailureCount());
+        assertEquals(1, worker.totalFailureCount());
+        assertTrue(worker.lastErrorMessage().contains("boom"));
+    }
+
+    @Test
+    void boundsLastErrorMessage() {
+        VidarObservationWorker worker = new VidarObservationWorker(() -> { });
+        worker.onTickFailure(new RuntimeException("x".repeat(500)));
+        assertEquals(VidarObservationWorker.MAX_ERROR_CHARS, worker.lastErrorMessage().length());
+    }
+
+    @Test
+    void threadStaysAliveAfterThrowThenSuccess() throws InterruptedException {
+        AtomicInteger ticks = new AtomicInteger();
+        CountDownLatch recovered = new CountDownLatch(1);
+        VidarObservationWorker worker = new VidarObservationWorker(() -> {
+            int n = ticks.getAndIncrement();
+            if (n == 0) {
+                throw new RuntimeException("tick failed");
+            }
+            recovered.countDown();
+        });
+        worker.start();
+        try {
+            assertTrue(recovered.await(5, TimeUnit.SECONDS), "worker should run a successful tick after the throw");
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+            while (System.nanoTime() < deadline && worker.consecutiveFailureCount() != 0) {
+                Thread.sleep(1);
+            }
+            assertTrue(worker.isAlive(), "worker thread must stay alive after a tick exception");
+            assertEquals(1, worker.totalFailureCount());
+            assertEquals(0, worker.consecutiveFailureCount());
+            assertTrue(worker.lastErrorMessage().contains("tick failed"));
+        } finally {
+            worker.shutdownAndJoin();
+        }
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarDiscoverOpMode.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarDiscoverOpMode.java
@@ -64,6 +64,14 @@ public class VidarDiscoverOpMode extends VidarSpatialOpModeBase {
             telemetry.addData("Cameras", spatial.diagnostics().connectedCameras
                     + "/" + spatial.diagnostics().cameraCount);
             telemetry.addData("Config", spatial.diagnostics().configSource);
+            if (spatial.diagnostics().observationWorkerTotalFailures > 0) {
+                telemetry.addData("Worker", "failures="
+                        + spatial.diagnostics().observationWorkerTotalFailures
+                        + " consecutive="
+                        + spatial.diagnostics().observationWorkerConsecutiveFailures
+                        + (spatial.diagnostics().observationWorkerLastError.isEmpty()
+                                ? "" : ": " + spatial.diagnostics().observationWorkerLastError));
+            }
             telemetry.addData("FPS cam1", spatial.cameraCount() > 0
                     && spatial.runtime().camera(0) != null
                     ? String.format("%.1f", spatial.runtime().camera(0).portalFps()) : "—");
@@ -96,6 +104,9 @@ public class VidarDiscoverOpMode extends VidarSpatialOpModeBase {
             telemetry.addData("Tag @capture", VidarBlobUtil.formatTagPose(tag));
             telemetry.addData("Field fused", formatFieldPose(fieldNow));
             for (String warning : spatial.diagnostics().warnings) {
+                if (warning.startsWith("Observation worker failures=")) {
+                    continue;
+                }
                 telemetry.addLine("⚠ " + warning);
             }
             telemetry.update();

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
@@ -7,6 +7,7 @@ import org.firstinspires.ftc.teamcode.vidar.frame.VidarSpatialSnapshot;
 import org.firstinspires.ftc.teamcode.vidar.fusion.VidarFusionEngine;
 import org.firstinspires.ftc.teamcode.vidar.model.VidarOffensiveLaneAnalysis;
 import org.firstinspires.ftc.teamcode.vidar.runtime.RuntimeBootstrap;
+import org.firstinspires.ftc.teamcode.vidar.runtime.VidarObservationWorker;
 import org.firstinspires.ftc.teamcode.vidar.runtime.VidarRuntime;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
@@ -314,7 +315,17 @@ public final class VidarSpatial {
         if (runtime.configSource() == VidarDiagnostics.ConfigSource.BUNDLED_DEFAULTS) {
             warnings.add(0, "Using bundled default season/robot JSON — deploy team assets for match tuning.");
         }
+        VidarObservationWorker worker = runtime.observationWorker();
+        String workerError = worker.lastErrorMessage();
+        int workerConsecutive = worker.consecutiveFailureCount();
+        int workerTotal = worker.totalFailureCount();
+        if (workerTotal > 0) {
+            warnings.add("Observation worker failures=" + workerTotal
+                    + " consecutive=" + workerConsecutive
+                    + (workerError.isEmpty() ? "" : ": " + workerError));
+        }
         diagnostics = new VidarDiagnostics(
-                runtime.configSource(), count, connected, warnings, health);
+                runtime.configSource(), count, connected, warnings, health,
+                workerError, workerConsecutive, workerTotal);
     }
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/api/VidarDiagnostics.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/api/VidarDiagnostics.java
@@ -24,6 +24,9 @@ public final class VidarDiagnostics {
     public final int connectedCameras;
     public final List<String> warnings;
     public final VidarMetrics.CameraHealth[] cameraHealth;
+    public final String observationWorkerLastError;
+    public final int observationWorkerConsecutiveFailures;
+    public final int observationWorkerTotalFailures;
 
     public VidarDiagnostics(
             ConfigSource configSource,
@@ -31,6 +34,18 @@ public final class VidarDiagnostics {
             int connectedCameras,
             List<String> warnings,
             VidarMetrics.CameraHealth[] cameraHealth) {
+        this(configSource, cameraCount, connectedCameras, warnings, cameraHealth, "", 0, 0);
+    }
+
+    public VidarDiagnostics(
+            ConfigSource configSource,
+            int cameraCount,
+            int connectedCameras,
+            List<String> warnings,
+            VidarMetrics.CameraHealth[] cameraHealth,
+            String observationWorkerLastError,
+            int observationWorkerConsecutiveFailures,
+            int observationWorkerTotalFailures) {
         this.configSource = configSource;
         this.cameraCount = cameraCount;
         this.connectedCameras = connectedCameras;
@@ -38,6 +53,10 @@ public final class VidarDiagnostics {
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(new ArrayList<>(warnings));
         this.cameraHealth = cameraHealth == null ? new VidarMetrics.CameraHealth[0] : cameraHealth;
+        this.observationWorkerLastError =
+                observationWorkerLastError == null ? "" : observationWorkerLastError;
+        this.observationWorkerConsecutiveFailures = observationWorkerConsecutiveFailures;
+        this.observationWorkerTotalFailures = observationWorkerTotalFailures;
     }
 
     public static VidarDiagnostics empty() {
@@ -54,6 +73,9 @@ public final class VidarDiagnostics {
         sb.append(" cameras=").append(connectedCameras).append('/').append(cameraCount);
         if (!warnings.isEmpty()) {
             sb.append(" warnings=").append(warnings.size());
+        }
+        if (observationWorkerTotalFailures > 0) {
+            sb.append(" workerFailures=").append(observationWorkerTotalFailures);
         }
         return sb.toString();
     }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarObservationWorker.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarObservationWorker.java
@@ -1,17 +1,41 @@
 package org.firstinspires.ftc.teamcode.vidar.runtime;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Persistent background worker — advances fusion and world model independently of the robot loop.
+ *
+ * <p>Tick {@link RuntimeException}s are recorded and the worker stays alive so perception does not
+ * take down the RC process. Students see last error and counts via {@link org.firstinspires.ftc.teamcode.vidar.api.VidarDiagnostics}.
  */
 public final class VidarObservationWorker extends Thread {
 
+    static final int MAX_ERROR_CHARS = 200;
+
     private final Runnable observationTick;
     private volatile boolean running = true;
+
+    private final AtomicReference<String> lastErrorMessage = new AtomicReference<>("");
+    private final AtomicInteger consecutiveFailureCount = new AtomicInteger(0);
+    private final AtomicInteger totalFailureCount = new AtomicInteger(0);
 
     public VidarObservationWorker(Runnable observationTick) {
         super("VidarObservationWorker");
         setPriority(Thread.NORM_PRIORITY - 1);
         this.observationTick = observationTick;
+    }
+
+    public String lastErrorMessage() {
+        return lastErrorMessage.get();
+    }
+
+    public int consecutiveFailureCount() {
+        return consecutiveFailureCount.get();
+    }
+
+    public int totalFailureCount() {
+        return totalFailureCount.get();
     }
 
     public void shutdownAndJoin() {
@@ -29,14 +53,37 @@ public final class VidarObservationWorker extends Thread {
         while (running) {
             try {
                 observationTick.run();
-            } catch (RuntimeException ignored) {
-                // Keep worker alive — perception must not depend on robot loop.
+                onTickSuccess();
+            } catch (RuntimeException ex) {
+                onTickFailure(ex);
             }
             if (!running) {
                 break;
             }
             sleepQuiet(1);
         }
+    }
+
+    /** Package-visible so tests can record without racing the 1 ms loop. */
+    void onTickSuccess() {
+        consecutiveFailureCount.set(0);
+    }
+
+    /** Package-visible so tests can record without racing the 1 ms loop. */
+    void onTickFailure(RuntimeException ex) {
+        lastErrorMessage.set(boundMessage(ex));
+        consecutiveFailureCount.incrementAndGet();
+        totalFailureCount.incrementAndGet();
+    }
+
+    static String boundMessage(Throwable ex) {
+        String name = ex.getClass().getSimpleName();
+        String detail = ex.getMessage();
+        String msg = (detail == null || detail.isEmpty()) ? name : name + ": " + detail;
+        if (msg.length() <= MAX_ERROR_CHARS) {
+            return msg;
+        }
+        return msg.substring(0, MAX_ERROR_CHARS);
     }
 
     private static void sleepQuiet(long ms) {

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
@@ -239,6 +239,10 @@ public final class VidarRuntime {
         return configSource;
     }
 
+    public VidarObservationWorker observationWorker() {
+        return observationWorker;
+    }
+
     public VidarGlobalVisionWorker globalVisionWorker() {
         return attachment == null ? null : attachment.globalVisionWorker();
     }


### PR DESCRIPTION
## Summary

Record `VidarObservationWorker` tick exceptions (bounded last error, consecutive and total counts) and show them on `VidarDiagnostics` and Discover telemetry. The worker stays alive.

Closes #20

## Problem

The observation worker swallowed every `RuntimeException` from `observationTick`, so perception could fail while OpModes kept reading last-good or empty snapshots with no diagnostic.

## Solution

Catch still keeps the RC process alive. Failures are recorded and published through diagnostics and one Discover `Worker` line when `totalFailures > 0`. Consecutive count resets on the next successful tick.

## Scope

- Worker failure recording
- Diagnostics + Discover
- java-pure `ObservationWorkerTest`
- SYSTEM_DESIGN + TEACHING notes

## Out of scope

Frame-gated world tracks (#21). Sim range fusion (#22). Camera restart loops. Empty-snapshot FAILED flag after N throws.

## Architecture impact

Additive diagnostics fields. Worker remains process-scoped. 5-arg `VidarDiagnostics` constructor still works (zeros worker counts).

## Safety impact

Improves visibility of dead perception. Does not command motors. Does not restart cameras in a fail loop.

## Compatibility impact

Additive public fields on `VidarDiagnostics`. Existing constructor overload preserved.

## Tests

- `ObservationWorkerTest`: record then success; bounded message; thread stays alive after throw
- Full `java-pure` suite (54 tests) on the implementation machine

## Validation results

Local `java-pure` tests reported BUILD SUCCESSFUL by the implementation subagent. CI on this PR is the merge gate.

## Hardware validation

Not performed. Not required for this slice.

## Documentation

`docs/SYSTEM_DESIGN.md` threading table; `docs/TEACHING.md` troubleshooting line.

## Risks

Noisy telemetry if fusion throws every tick — message is capped at 200 characters.

## Rollback or disable strategy

Revert the PR. Worker returns to silent swallow-and-stay-alive without diagnostics.

## Known limitations

Does not force empty snapshots after N consecutive failures. Discover confirmation on a hub is still optional.

## Related issue

Closes #20