### PR TITLE
Gate world-model tracks on new vision frames

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -105,7 +105,7 @@ Pipeline: **HSV mask → contour → `minAreaRect` → white-digit ratio → wid
 
 ## Phase 3 — World model & assisted behaviors ✅ foundation
 
-`VidarWorldModel` keeps short-term tracks (elements, allies, foes) with TTL merge.
+`VidarWorldModel` keeps short-term tracks (elements, allies, foes) with TTL merge. Association clocks on new vision capture times, not 1 ms worker ticks.
 
 | Behavior | Uses |
 |----------|------|

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -132,6 +132,8 @@ Component estimates exposed as `source0`, `source1`, and `sourceCount` (up to 3)
 
 `VidarWorldModel` motion-corrects tracks using odom delta (translation + rotation) or field-pose reprojection when available. Owned by `VidarRuntime` and persists across camera detach.
 
+Association and TTL clock off **observation capture time**, not the ~1 ms observation-worker tick. Repeating the same fused detections (same `captureTimeNanos`) is a miss/coast: `lastSeenNanos` is not refreshed from stale blobs. `update(null, now)` also coasts so `detachVision()` ages tracks. After `WORLD_*_TTL_SEC` with no new frame, tracks are pruned and `intakeBlocked()` goes false. Tracks expose `lastSeenNanos` and `missCount` — treat high miss count or age as stale. Set `WORLD_ASSOCIATE_ON_NEW_FRAME_ONLY` false to restore last-blob re-association every tick.
+
 ## Spatial facade — **Implemented**, **Tested in simulation**
 
 `VidarSpatial` is the Pedro-style entry point. Perception advances in the background; read `snapshot()` each loop.

--- a/docs/TEACHING.md
+++ b/docs/TEACHING.md
@@ -65,6 +65,8 @@ Build and deploy to the Control Hub like any other OpMode.
 
 **Goal:** See every remembered element and foe track after `update()`. **No motors** — map lists to Pedro or your follower in team code.
 
+Remembered tracks age with **new camera frames**. Replaying the last blob on the 1 ms worker does not keep a track alive. High `missCount` or old `lastSeenNanos` means the memory is stale.
+
 Calibrate first: [CALIBRATION_CHECKLIST.md](CALIBRATION_CHECKLIST.md).
 
 Try the same logic in the **browser sim** first — sidebar shows range and spatial overlays.

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -17,20 +17,20 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#20](https://github.com/The-Allsparks/ViDAR/issues/20) |
-| Why highest priority | Silent worker exceptions hide dead perception behind last-good snapshots |
-| Why ready | #13/#18 merged; no hardware required; acceptance is JVM-testable |
+| Selected issue | [#21](https://github.com/The-Allsparks/ViDAR/issues/21) |
+| Why highest priority | Last-blob re-association on 1 ms ticks never fires TTL; detach freezes tracks |
+| Why ready | #20 merged; no hardware required; acceptance is JVM-testable |
 | Dependencies | None |
-| Expected deliverable | Worker records last error + count; `VidarDiagnostics` / Discover show it; worker stays alive |
-| Expected validation | java-pure worker test + CI |
+| Expected deliverable | Associate/coast/prune on capture time; detach ages tracks; java-pure world tests |
+| Expected validation | `cd java-pure && ./gradlew.bat test --no-daemon` |
 | Hardware required | No |
-| Branch | `fix/observation-worker-failure-visibility` (planned) |
+| Branch | `fix/frame-gated-world-association` |
 | Pull request | not opened yet |
 | CI status | — |
 | Merge status | — |
-| Last delivered | [#13](https://github.com/The-Allsparks/ViDAR/issues/13) via [#18](https://github.com/The-Allsparks/ViDAR/pull/18) merge `65af3c2` |
+| Last delivered | [#20](https://github.com/The-Allsparks/ViDAR/issues/20) via [#31](https://github.com/The-Allsparks/ViDAR/pull/31) merge `2c2b7d7` |
 
-#18 is merged. One implementation issue at a time: #20 next.
+#20 is merged. One implementation issue at a time: #21 next.
 
 ## Ledger
 
@@ -38,8 +38,8 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 |-------|----------|-----------|--------------|--------|----------|--------|----|----|-------|---------|-------------|
 | #19 Roadmap epic | P0 process | Active | — | Open | orchestrator | `docs/initial-deep-audit` | docs PR this cycle | — | — | — | Keep ledger in sync |
 | #13 Geometry-authoritative ranging | P0 | Done | #17 done | **Merged** | review | `feature/geometry-authoritative-ranging` | #18 | pass | **merged** `65af3c2` | — | Closed |
-| #20 Worker failure visibility (S3) | P1 | **Ready** | #18 done | Selected | pending | `fix/observation-worker-failure-visibility` | — | — | — | — | Implement |
-| #21 Frame-generation association (A2/C4) | P1 | Ready | #18 done | Open | — | — | — | — | — | Wait for #20 PR | After #20 |
+| #20 Worker failure visibility (S3) | P1 | Done | #18 done | **Merged** | review | `fix/observation-worker-failure-visibility` | #31 | pass | **merged** `2c2b7d7` | — | Closed |
+| #21 Frame-generation association (A2/C4) | P1 | Ready | #20 done | In progress | implement | `fix/frame-gated-world-association` | — | — | — | — | Implement / push |
 | #22 Sim range-fusion parity (C2) | P1 | Ready | #13/#18 done | Open | — | — | — | — | — | Wait for #20 PR | After #20/#21 |
 | #23 Runtime/world java-pure tests (T1) | P2 | Blocked | #21 preferred first | Filed | — | — | — | — | — | #21 | After #21 or same slice |
 | #24 java-pure required check (T2) | P2 | Ready (settings) | None | Filed | — | — | — | — | — | Settings | After current implementation PR |

--- a/java-pure/build.gradle
+++ b/java-pure/build.gradle
@@ -29,7 +29,6 @@ sourceSets {
             srcDir teamcodeVidar
             exclude 'detect/**'
             exclude 'schedule/**'
-            exclude 'world/**'
             exclude '**/*OpMode.java'
             exclude 'geometry/VidarObservationSpatial.java'
             exclude 'geometry/VidarPoseLookup.java'
@@ -39,7 +38,6 @@ sourceSets {
             exclude 'VidarAutoSeekOpMode.java'
             exclude 'VidarRoiCalibrationOpMode.java'
             exclude 'fusion/VidarFusionEngine.java'
-            exclude 'VidarSpatialPoint.java'
             exclude 'VidarSpatial.java'
             exclude 'VidarSpatialOpModeBase.java'
             exclude 'VidarObservationMapper.java'
@@ -63,7 +61,6 @@ sourceSets {
             exclude 'runtime/VidarMetricsLogger.java'
             exclude 'runtime/VidarAllianceSelector.java'
             exclude 'model/VidarElementDensityMap.java'
-            exclude 'model/VidarElementOccurrenceRank.java'
             exclude 'model/VidarElementRejectionStats.java'
             exclude 'model/VidarOffensiveLaneAnalysis.java'
             exclude 'api/VidarDiagnostics.java'

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/world/WorldModelAssociationTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/world/WorldModelAssociationTest.java
@@ -1,0 +1,146 @@
+package org.firstinspires.ftc.teamcode.vidar.world;
+
+import org.firstinspires.ftc.teamcode.vidar.VidarConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorldModelAssociationTest {
+
+    private static final long CAPTURE = 1000L;
+    private static final long MS = 1_000_000L;
+
+    @Test
+    void birthsTrackFromDetection() {
+        VidarWorldModel world = model();
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE);
+
+        assertEquals(1, world.trackCount());
+        VidarSpatialTrack track = world.getTracks().get(0);
+        assertEquals(0, track.missCount);
+        assertEquals(CAPTURE, track.lastSeenNanos);
+        assertEquals(VidarWorldModel.Kind.ELEMENT, track.kind);
+    }
+
+    @Test
+    void replayingSameCaptureIsAMissNotAHit() {
+        VidarWorldModel world = model();
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE);
+        long lastSeen = world.getTracks().get(0).lastSeenNanos;
+
+        long later = CAPTURE + nanos(0.2);
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, later);
+
+        assertEquals(1, world.trackCount());
+        VidarSpatialTrack track = world.getTracks().get(0);
+        assertTrue(track.missCount > 0, "stale capture must coast, not reset TTL");
+        assertEquals(lastSeen, track.lastSeenNanos);
+    }
+
+    @Test
+    void sameCapturePastTtlPrunesTrack() {
+        VidarWorldModel world = model();
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE);
+
+        long pastTtl = CAPTURE + nanos(VidarConfig.WORLD_ELEMENT_TTL_SEC + 0.1);
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, pastTtl);
+
+        assertEquals(0, world.trackCount());
+    }
+
+    @Test
+    void emptyDetectionsPastTtlPruneTrack() {
+        VidarWorldModel world = model();
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE);
+
+        long pastTtl = CAPTURE + nanos(VidarConfig.WORLD_ELEMENT_TTL_SEC + 0.1);
+        world.updateFromDetections(Collections.emptyList(), 0L, pastTtl);
+
+        assertEquals(0, world.trackCount());
+    }
+
+    @Test
+    void updateNullCoastsAndPrunesAfterTtl() {
+        VidarWorldModel world = model();
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE);
+        assertEquals(1, world.trackCount());
+
+        world.update(null, CAPTURE + nanos(0.2));
+        assertEquals(1, world.trackCount());
+        assertTrue(world.getTracks().get(0).missCount > 0);
+
+        world.update(null, CAPTURE + nanos(VidarConfig.WORLD_ELEMENT_TTL_SEC + 0.1));
+        assertEquals(0, world.trackCount());
+    }
+
+    @Test
+    void oneMillisecondStaleReplaysDoNotCountAsMissFrames() {
+        VidarWorldModel world = model();
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE);
+        long lastSeen = world.getTracks().get(0).lastSeenNanos;
+
+        for (int i = 1; i <= 20; i++) {
+            world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE + i * MS);
+        }
+
+        assertEquals(1, world.trackCount());
+        VidarSpatialTrack track = world.getTracks().get(0);
+        assertEquals(lastSeen, track.lastSeenNanos);
+        assertTrue(track.missCount <= 1, "1 ms worker ticks must not explode missCount");
+    }
+
+    @Test
+    void intakeBlockedClearsWhenFoeTrackPruned() {
+        VidarWorldModel world = model();
+        VidarTrackDetection foe = new VidarTrackDetection(
+                VidarWorldModel.Kind.FOE, "", -1, 20.0, 0.0, 20.0, 0.9, "Webcam 1", CAPTURE);
+        world.updateFromDetections(List.of(foe), CAPTURE, CAPTURE);
+        assertTrue(world.intakeBlocked());
+
+        long pastTtl = CAPTURE + nanos(VidarConfig.WORLD_FOE_TTL_SEC + 0.1);
+        world.updateFromDetections(Collections.emptyList(), 0L, pastTtl);
+
+        assertEquals(0, world.trackCount());
+        assertFalse(world.intakeBlocked());
+    }
+
+    @Test
+    void associatorPrunesAfterMaxMissFrames() {
+        VidarWorldModel world = model();
+        world.updateFromDetections(List.of(element(CAPTURE)), CAPTURE, CAPTURE);
+
+        long now = CAPTURE + nanos(VidarConfig.WORLD_TRACK_MIN_DT_SEC);
+        for (int i = 0; i <= VidarConfig.WORLD_TRACK_MAX_MISS_FRAMES; i++) {
+            now += nanos(VidarConfig.WORLD_TRACK_MIN_DT_SEC);
+            world.updateFromDetections(Collections.emptyList(), 0L, now);
+        }
+
+        assertEquals(0, world.trackCount());
+    }
+
+    private static VidarWorldModel model() {
+        return new VidarWorldModel(() -> null, null);
+    }
+
+    private static VidarTrackDetection element(long captureNanos) {
+        return new VidarTrackDetection(
+                VidarWorldModel.Kind.ELEMENT,
+                "artifact_purple",
+                0,
+                12.0,
+                0.0,
+                12.0,
+                0.9,
+                "Webcam 1",
+                captureNanos);
+    }
+
+    private static long nanos(double seconds) {
+        return (long) (seconds * 1_000_000_000L);
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarConfig.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarConfig.java
@@ -272,6 +272,11 @@ public final class VidarConfig {
     // --- Short-term world model (VidarWorldModel) ---
     /** When false, skip motion correction and track memory (live vision only). */
     public static final boolean WORLD_MOTION_TRACKING_ENABLED = true;
+    /**
+     * Associate/coast on new observation capture times, not 1 ms worker ticks.
+     * Set false to restore last-blob re-association every tick (rollback).
+     */
+    public static final boolean WORLD_ASSOCIATE_ON_NEW_FRAME_ONLY = true;
     public static final double WORLD_ELEMENT_TTL_SEC = 2.5;
     public static final double WORLD_FOE_TTL_SEC = 3.0;
     public static final double WORLD_ALLY_TTL_SEC = 4.0;

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
@@ -279,6 +279,8 @@ public final class VidarRuntime {
                 }
                 engine.update();
                 world.update(engine, System.nanoTime());
+            } else {
+                world.update(null, System.nanoTime());
             }
         }
         if (engine != null) {

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/world/VidarWorldModel.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/world/VidarWorldModel.java
@@ -9,6 +9,7 @@ import org.firstinspires.ftc.teamcode.vidar.model.VidarElementOccurrenceRank;
 import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -16,6 +17,11 @@ import java.util.function.Supplier;
  * Short-term spatial memory with predict/gate/associate tracking.
  *
  * <p>When {@link #isMotionTrackingActive()} is false, {@link #update} is a no-op — live vision only.
+ *
+ * <p>Association clocks on observation {@code captureTimeNanos}, not observation-worker ticks.
+ * Repeating the same fused detections is a miss; {@code update(null, now)} coasts so detach ages
+ * tracks. Consumers should treat high {@link VidarSpatialTrack#missCount} or old
+ * {@link VidarSpatialTrack#lastSeenNanos} as stale.
  */
 public class VidarWorldModel {
 
@@ -30,6 +36,10 @@ public class VidarWorldModel {
     private Supplier<Pose2D> fieldPoseSupplier;
     private boolean motionTrackingEnabled = VidarConfig.WORLD_MOTION_TRACKING_ENABLED;
     private int nextTrackId = 1;
+    /** Max captureTimeNanos from the last fused frame that was treated as new. */
+    private long lastObservationCaptureNanos;
+    /** Wall-clock of the last associate/coast so 1 ms ticks do not count as miss frames. */
+    private long lastAssociateNanos;
 
     public VidarWorldModel() {
         this(null, null);
@@ -44,8 +54,7 @@ public class VidarWorldModel {
     public void setOdomSupplier(Supplier<Pose2D> odomSupplier) {
         this.odomSupplier = odomSupplier;
         if (!isMotionTrackingActive()) {
-            tracks.clear();
-            nextTrackId = 1;
+            clearTracks();
         }
     }
 
@@ -56,8 +65,7 @@ public class VidarWorldModel {
     public void setMotionTrackingEnabled(boolean enabled) {
         this.motionTrackingEnabled = enabled;
         if (!isMotionTrackingActive()) {
-            tracks.clear();
-            nextTrackId = 1;
+            clearTracks();
         }
     }
 
@@ -70,19 +78,72 @@ public class VidarWorldModel {
     }
 
     public void update(VidarVisionFusion vision, long nowNanos) {
-        if (!isMotionTrackingActive() || vision == null) {
+        if (!isMotionTrackingActive()) {
             return;
         }
 
+        List<VidarTrackDetection> detections = vision == null
+                ? Collections.emptyList()
+                : collectDetections(vision);
+        updateFromDetections(detections, maxCaptureNanos(detections), nowNanos);
+    }
+
+    /**
+     * Associate, coast, or prune using an explicit detection list and observation capture time.
+     * Package-visible so java-pure tests can drive the world model without a fusion engine.
+     */
+    void updateFromDetections(
+            List<VidarTrackDetection> detections, long observationCaptureNanos, long nowNanos) {
+        List<VidarTrackDetection> toAssociate =
+                detections == null ? Collections.emptyList() : detections;
+
+        boolean staleFrame = VidarConfig.WORLD_ASSOCIATE_ON_NEW_FRAME_ONLY
+                && observationCaptureNanos != 0
+                && observationCaptureNanos == lastObservationCaptureNanos;
+        if (staleFrame) {
+            toAssociate = Collections.emptyList();
+        }
+
+        boolean newFrame = observationCaptureNanos != 0
+                && observationCaptureNanos != lastObservationCaptureNanos;
+        if (toAssociate.isEmpty() && shouldSkipIdleCoast(nowNanos)) {
+            return;
+        }
+
+        if (newFrame) {
+            lastObservationCaptureNanos = observationCaptureNanos;
+        }
+        lastAssociateNanos = nowNanos;
+
         Pose2D fieldPose = fieldPoseSupplier == null ? null : fieldPoseSupplier.get();
-        List<VidarTrackDetection> detections = collectDetections(vision);
         List<VidarSpatialTrack> current = new ArrayList<>(tracks);
         int[] nextId = { nextTrackId };
         List<VidarSpatialTrack> associated = VidarTrackAssociator.associate(
-                current, detections, fieldPose, nowNanos, nextId);
+                current, toAssociate, fieldPose, nowNanos, nextId);
         tracks.clear();
         tracks.addAll(associated);
         nextTrackId = nextId[0];
+    }
+
+    private boolean shouldSkipIdleCoast(long nowNanos) {
+        if (lastAssociateNanos <= 0) {
+            return false;
+        }
+        return VidarSpatialTrack.dtSeconds(lastAssociateNanos, nowNanos)
+                < VidarConfig.WORLD_TRACK_MIN_DT_SEC;
+    }
+
+    private static long maxCaptureNanos(List<VidarTrackDetection> detections) {
+        long max = 0L;
+        if (detections == null) {
+            return max;
+        }
+        for (VidarTrackDetection detection : detections) {
+            if (detection != null && detection.captureTimeNanos > max) {
+                max = detection.captureTimeNanos;
+            }
+        }
+        return max;
     }
 
     private List<VidarTrackDetection> collectDetections(VidarVisionFusion vision) {
@@ -181,7 +242,13 @@ public class VidarWorldModel {
 
     /** Clear short-term tracks between match periods. */
     public void resetMatchState() {
+        clearTracks();
+    }
+
+    private void clearTracks() {
         tracks.clear();
         nextTrackId = 1;
+        lastObservationCaptureNanos = 0L;
+        lastAssociateNanos = 0L;
     }
 }


### PR DESCRIPTION
## Summary

World-model association and TTL now clock on observation `captureTimeNanos`, not the ~1 ms observation worker. Repeating the last fused blobs is a miss. `update(null)` coasts so Auto→TeleOp detach ages tracks out.

Closes #21

## Problem

Last processor detections were re-associated every worker tick, refreshing `lastSeenNanos` with `missCount == 0`, so TTL never fired. On camera detach, `VidarWorldModel.update` returned immediately and frozen tracks could still appear in snapshots.

## Solution

- `WORLD_ASSOCIATE_ON_NEW_FRAME_ONLY` (default true): same capture time → empty associate (coast), not a hit
- Idle coast gated by `WORLD_TRACK_MIN_DT_SEC` so 1 ms ticks do not explode `missCount`
- Detached runtime still calls `world.update(null, now)`
- java-pure `WorldModelAssociationTest` covers birth, stale replay, TTL, detach, 1 ms ticks, `intakeBlocked`, max miss frames

## Scope

World-model association clock, detach coast, JVM tests, brief docs.

## Out of scope

Sim range fusion (#22). Snapshot DTO copy of missCount. Hardware occlusion validation.

## Architecture impact

Association is frame-time, not worker-time. Snapshot getters unchanged.

## Safety impact

Stale foe tracks no longer look live forever; `intakeBlocked()` clears when the foe track is pruned. No motors.

## Compatibility impact

Additive config flag defaulting to the new (safer) behavior. Public snapshot lists still the same types.

## Tests

`WorldModelAssociationTest` (8 cases). Full java-pure suite reported BUILD SUCCESSFUL on the implementation machine.

## Validation results

Local `cd java-pure && ./gradlew.bat test --no-daemon` — BUILD SUCCESSFUL. CI on this PR is the merge gate.

## Hardware validation

Not performed. Not required for this slice.

## Documentation

SYSTEM_DESIGN world-model paragraph; TEACHING/ROADMAP notes; ledger.

## Risks

Slow cameras: one coast miss can occur between frames after `WORLD_TRACK_MIN_DT_SEC`. Max miss frames (8) plus TTL still govern prune. Flag can disable frame gating if a team must restore old stickiness.

## Rollback or disable strategy

Set `VidarConfig.WORLD_ASSOCIATE_ON_NEW_FRAME_ONLY = false`, or revert the PR.

## Known limitations

Empty detections use capture 0; idle interval distinguishes empty ticks. `VidarSpatialPoint` still does not copy `missCount`/`lastSeenNanos`.

## Related issue

Closes #21
