### PR TITLE
Pin java-compile FTC SDK to v11.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,12 @@ jobs:
           distribution: temurin
           java-version: "17"
       - name: Compile ViDAR Java against FTC SDK
+        env:
+          # Keep in sync with README / CONTRIBUTING "Supported FTC SDK".
+          FTC_SDK_REF: v11.2.1
         run: |
-          git clone --depth 1 https://github.com/FIRST-Tech-Challenge/FtcRobotController.git /tmp/ftc
+          git clone --depth 1 --branch "$FTC_SDK_REF" \
+            https://github.com/FIRST-Tech-Challenge/FtcRobotController.git /tmp/ftc
           mkdir -p /tmp/ftc/TeamCode/src/main/java/org/firstinspires/ftc/teamcode
           cp -r teamcode/org/firstinspires/ftc/teamcode/vidar \
             /tmp/ftc/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/
@@ -37,6 +41,7 @@ jobs:
           cd /tmp/ftc
           chmod +x gradlew
           ./gradlew :TeamCode:compileDebugJavaWithJavac --no-daemon
+          echo "Compiled against FTC SDK $FTC_SDK_REF"
 
   java-pure:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,17 @@ teamcode/org/firstinspires/ftc/teamcode/vidar/
 
 See [README.md](README.md) for OpMode names and configuration.
 
+### Supported FTC SDK
+
+CI `java-compile` clones [FtcRobotController](https://github.com/FIRST-Tech-Challenge/FtcRobotController) at a **pinned tag**, not `main` tip.
+
+| Field | Value |
+|-------|--------|
+| **Supported tag** | `v11.2.1` |
+| **Workflow env** | `FTC_SDK_REF` in `.github/workflows/test.yml` |
+
+Bump the pin deliberately when validating a newer SDK; do not treat an unpinned clone as compatibility proof. Desktop `java-pure` tests do **not** claim Control Hub readiness.
+
 ## Do not commit
 
 - `.env` or credentials

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ python -m pytest tests/ -v
 
 ### 2. Install on the Control Hub
 
-1. Clone the [FTC SDK](https://github.com/FIRST-Tech-Challenge/FtcRobotController) and open it in Android Studio.
+1. Clone the [FTC SDK](https://github.com/FIRST-Tech-Challenge/FtcRobotController) at the supported tag **`v11.2.1`** (or newer only after ViDAR CI is updated) and open it in Android Studio.
 2. Copy the entire `teamcode/org/firstinspires/ftc/teamcode/vidar/` tree (including subpackages) → `TeamCode/src/main/java/.../vidar/`. See [docs/JAVA_PACKAGE_MAP.md](docs/JAVA_PACKAGE_MAP.md).
 3. Copy `teamcode/assets/vidar/` → `TeamCode/src/main/assets/vidar/` (includes `default-season.json` / `default-robot.json` fallbacks plus your `season.json` / `robot.json` overrides).
 4. Copy a robot template from [`config/robots/`](config/robots/README.md) to `TeamCode/src/main/assets/vidar/robot.json` (or edit the bundled default).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ ViDAR already ships TeamCode sources, `java-pure` tests, and FTC-oriented CI. Th
 | Gap | Tracking |
 |-----|----------|
 | Versioned install (source-copy may remain supported) | #33 |
-| Pinned FTC SDK in `java-compile` CI | [#29](https://github.com/The-Allsparks/ViDAR/issues/29) (child of #33) |
+| Pinned FTC SDK in `java-compile` CI | [#29](https://github.com/The-Allsparks/ViDAR/issues/29) (child of #33) — pin target `v11.2.1` |
 | Documented VisionPortal ownership + `stop()` release across OpMode transitions | #33 |
 | Control Hub 1–4 camera / USB validation log | [#26](https://github.com/The-Allsparks/ViDAR/issues/26), [#27](https://github.com/The-Allsparks/ViDAR/issues/27) |
 | Narrow adapter contracts for BEACON / HELM / ECHO / TRACE | #33 |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -2,7 +2,7 @@
 
 Living ledger for orchestrator selection. GitHub issues are authoritative; this file is the in-repo snapshot.
 
-**Updated:** 2026-08-20  
+**Updated:** 2026-08-20 (post-#34)  
 **Identity:** `TA-C-GHill`  
 **Max active implementation PRs:** 1
 
@@ -18,22 +18,23 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#34](https://github.com/The-Allsparks/ViDAR/issues/34) then [#29](https://github.com/The-Allsparks/ViDAR/issues/29) as first #33 child |
-| Why highest priority | #33 is the P0 FTC packaging/lifecycle epic; ledger must list it first; SDK pin is the smallest non-hardware child |
-| Why ready | Docs-only (#34); CI pin (#29) needs no Control Hub |
-| Dependencies | None for #34; #29 is a child of #33 |
-| Expected deliverable | Ledger/ROADMAP list #33 first; then pinned FTC SDK in `java-compile` |
-| Hardware required | No for this cycle |
-| Last delivered | [#21](https://github.com/The-Allsparks/ViDAR/issues/21) via [#32](https://github.com/The-Allsparks/ViDAR/pull/32) merge `e6006b0` |
+| Selected issue | [#29](https://github.com/The-Allsparks/ViDAR/issues/29) (first software child of [#33](https://github.com/The-Allsparks/ViDAR/issues/33)) |
+| Why highest priority | Smallest non-hardware #33 acceptance item: stop compiling against unpinned SDK tip |
+| Why ready | Tag `v11.2.1` exists; no Control Hub required |
+| Dependencies | #34 ledger sync merged (`95cedfd`) |
+| Expected deliverable | `java-compile` clones `--branch v11.2.1`; docs name the pin |
+| Hardware required | No |
+| Branch | `fix/pin-ftc-sdk-java-compile` |
+| Last delivered | [#34](https://github.com/The-Allsparks/ViDAR/issues/34) via [#35](https://github.com/The-Allsparks/ViDAR/pull/35) |
 
 ## Ledger
 
 | Issue | Priority | Readiness | Dependencies | Status | Branch / PR | Blocker | Next action |
 |-------|----------|-----------|--------------|--------|-------------|---------|-------------|
 | **#33 FTC packaging & lifecycle** | **P0 readiness** | **Active epic** | FORGE#4 (combined) | Open | — | Hardware for USB rows | Split children; start with #29 |
-| #34 Record #33 as first priority | P0 docs | Ready | #33 | This PR | `docs/ftc-integration-priority-ledger` | — | Merge |
+| #34 Record #33 as first priority | P0 docs | Done | #33 | **Merged** #35 `95cedfd` | — | — | Closed |
 | #19 Roadmap epic | P0 process | Active | — | Open | — | — | Keep checklist in sync |
-| #29 Pin FTC SDK in java-compile | P0 child of #33 | Ready | #33 | Open | — | — | Implement after #34 |
+| #29 Pin FTC SDK in java-compile | P0 child of #33 | In progress | #33 | This PR | `fix/pin-ftc-sdk-java-compile` | — | Merge when CI green |
 | #13 Geometry-authoritative ranging | Done | Done | #17 | **Merged** #18 | — | — | Closed |
 | #20 Worker failure visibility | Done | Done | #18 | **Merged** #31 | — | — | Closed |
 | #21 Frame-gated world association | Done | Done | #20 | **Merged** #32 `e6006b0` | — | — | Closed |


### PR DESCRIPTION
## Summary

`java-compile` now clones `FtcRobotController` at tag **`v11.2.1`** via `FTC_SDK_REF`. README and CONTRIBUTING name the supported SDK. Part of the [#33](https://github.com/The-Allsparks/ViDAR/issues/33) packaging gate.

Closes #29
Part of #33

## Problem

CI cloned the FTC SDK at default-branch tip, so Hub compatibility was a moving target.

## Solution

Pin `--branch v11.2.1` and document the pin. Desktop `java-pure` still does not claim Control Hub readiness.

## Scope

Workflow pin + docs. Ledger update for current cycle.

## Out of scope

Versioned Maven/composite install (#33 remainder). Actions SHA pins (#25). Hardware validation (#26/#27).

## Architecture impact

None on runtime. CI contract becomes explicit.

## Safety impact

None.

## Compatibility impact

Teams should develop against `v11.2.1` (or bump the pin after validating a newer tag).

## Tests

CI `java-compile` against the pin is the acceptance test.

## Validation results

Pending CI on this PR.

## Hardware validation

Not performed. Not required for this slice.

## Documentation

README install step, CONTRIBUTING supported-SDK table, ROADMAP P0 row, ledger.

## Risks

`v11.2.1` may differ from a team`s local SDK; document bump process.

## Rollback or disable strategy

Revert to unpinned clone (not preferred) or change `FTC_SDK_REF`.

## Known limitations

Does not implement versioned TeamCode packaging by itself.

## Related issue

Closes #29