### PR TITLE
Add architecture CI guards and quality/performance baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: gradle
+    directory: /java-pure
+    schedule:
+      interval: monthly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -9,18 +12,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install -r requirements-dev.txt
-      - run: python -m pytest tests/ -v
+      - name: Python tests (parity + architecture guards)
+        run: python -m pytest tests/ -v
 
   java-compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "17"
@@ -46,8 +50,8 @@ jobs:
   java-pure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "17"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# Agent and contributor expectations
+
+This file is for humans and coding agents working in The-Allsparks/ViDAR.
+
+Treat ViDAR as production FTC library software. Features that work in isolation are not enough: new code must stay organized, testable, and hard to accidentally degrade.
+
+## What ViDAR is
+
+ViDAR converts USB webcam detections into timestamped **robot-space** observations (elements, alliance plates, sparse AprilTags). It is **passive**: it must never command motors or servos.
+
+Competition path: Java TeamCode on the Control Hub (`teamcode/.../vidar/`). Python, Docker, and the browser sim are off-robot only.
+
+## Module responsibilities
+
+| Area | Responsibility | Must not |
+|------|----------------|----------|
+| `vidar` root | Public facade (`VidarSpatial`), enums, sample OpModes | Own hardware threads or OpenCV loops |
+| `vidar.runtime` | Process singleton, camera attach/detach, workers | Pathing / motor APIs |
+| `vidar.detect` | Contour / plate OpenCV pipelines | Field pose ownership |
+| `vidar.tag` | Scout + budgeted AprilTag decode | Alter pose from scout observations |
+| `vidar.fusion` | Multi-camera pick, localization gates | Direct VisionPortal construction |
+| `vidar.world` | Short-term tracks, TTL, association | HardwareMap / OpenCV |
+| `vidar.geometry` | Transforms, ground plane, range fusion | Detect/tag implementations |
+| `vidar.integration` | Optional Pedro adapters | Compile dependency on Pedro |
+| `vidar.config` | Season/robot JSON | Detection algorithms |
+| `sim/` + `src/vidar/` | Parity / teaching | Claim Control Hub performance |
+
+Allowed dependency direction and the frozen import graph: [docs/JAVA_PACKAGE_MAP.md](docs/JAVA_PACKAGE_MAP.md) and `tests/architecture/allowed_package_edges.json`.
+
+**New package edges fail CI.** If a dependency is truly required, update the freeze file in the same PR and explain why. Hard-forbidden inversions (`geometry` → `detect`, `integration` → `runtime`, etc.) cannot be waived via the freeze file.
+
+## Commands
+
+```powershell
+pip install -r requirements-dev.txt
+python -m pytest tests/ -v
+# architecture guards live under tests/architecture/ and run with pytest
+
+cd java-pure
+.\gradlew.bat test --no-daemon
+
+python scripts/run_tests.py
+python scripts/bench_metrics.py
+```
+
+There is no repo-wide Java formatter yet (Spotless deferred — formatting the existing tree is a dedicated change). Match surrounding TeamCode style: 4-space indent, existing class/method conventions.
+
+## Tests for new functionality
+
+- Logic that does not need OpenCV, VisionPortal, or HardwareMap belongs in `java-pure` JVM tests.
+- Config / geometry / fusion math also needs a Python parity test when the browser sim or `src/vidar` mirrors it.
+- Lifecycle, TTL, and worker behavior must not be “tested only on a hub.”
+- Do not add Android emulator or EasyOpenCV jobs without an issue.
+
+## Performance
+
+See [docs/PERFORMANCE.md](docs/PERFORMANCE.md).
+
+Critical paths: VisionPortal callback, contour/tag process, `VidarObservationWorker` (~1 ms tick), `VidarRuntime.observationTick()`, OpMode `loop()`.
+
+On those paths:
+
+- Do not add `Thread.sleep`, filesystem I/O, or network calls.
+- Do not construct `VisionPortal.Builder` outside attach/init (`VidarVision`).
+- Do not allocate unbounded queues. Mailboxes are latest-wins.
+- Prefer reused Mats / scratch buffers over per-frame `new ArrayList` / `String.format` in workers. OpMode telemetry formatting is allowed but keep it modest.
+- Do not “optimize” Control Hub behavior without measurement ([issue #27](https://github.com/The-Allsparks/ViDAR/issues/27)).
+
+CI may only apply **generous** JVM ceilings (algorithmic catastrophe), never millisecond Hub budgets.
+
+## Dependencies
+
+- Prefer no new Maven/pip dependencies. java-pure is Java 11 bytecode; CI compiles TeamCode against FTC SDK **v11.2.1**.
+- Do not add a DI framework.
+- Do not add ArchUnit to TeamCode (Android/FTC). Architecture is enforced by source tests under `tests/architecture/`.
+- Pedro Pathing stays an optional consumer in `vidar.integration` with no Maven dependency.
+
+## Public API
+
+Teams are expected to call `VidarSpatial`, snapshot types, diagnostics, JSON config, and optional Pedro adapters.
+
+Do not widen `VidarSpatial.runtime()` or other internals without an issue. Do not break existing `create` / `update` / `snapshot` / `close` signatures without a documented migration.
+
+## Architectural changes
+
+If you change package boundaries, threading, or snapshot publication, update `docs/JAVA_PACKAGE_MAP.md`, `docs/SYSTEM_DESIGN.md`, and architecture tests in the same PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ python scripts/run_tests.py
 
 Tests use a pure-Python mirror of core Java logic in `tests/pure/` — no Control Hub or OpenCV required.
 
+`tests/architecture/` is part of the same pytest run. It freezes the Java package import graph, forbids drivetrain commands, and blocks `Thread.sleep` / `VisionPortal.Builder` on hot paths. See [AGENTS.md](AGENTS.md).
+
 ### Java unit tests (java-pure)
 
 JVM tests compile selected TeamCode classes with Android/FTC stubs:
@@ -32,6 +34,8 @@ Or run everything:
 ```powershell
 python scripts/run_tests.py
 ```
+
+`java-pure` runs in GitHub Actions. Make it a **required** check on `main` (issue #24) so a red JVM suite cannot merge. Today branch protection requires `test (ubuntu-latest)`, `test (windows-latest)`, and `java-compile` against FTC SDK `v11.2.1`.
 
 ## Browser simulator
 
@@ -62,6 +66,14 @@ CI `java-compile` clones [FtcRobotController](https://github.com/FIRST-Tech-Chal
 | **Workflow env** | `FTC_SDK_REF` in `.github/workflows/test.yml` |
 
 Bump the pin deliberately when validating a newer SDK; do not treat an unpinned clone as compatibility proof. Desktop `java-pure` tests do **not** claim Control Hub readiness.
+
+## Quality and performance
+
+- [AGENTS.md](AGENTS.md) — architecture, tests, hot-path rules for humans and coding agents
+- [docs/JAVA_PACKAGE_MAP.md](docs/JAVA_PACKAGE_MAP.md) — packages and allowed dependency direction
+- [docs/PERFORMANCE.md](docs/PERFORMANCE.md) — Hub vs desktop measurement; what CI can and cannot gate
+
+Do not add Java/Android static-analysis plugins to TeamCode without checking FTC SDK compatibility. Architecture is enforced with source tests, not ArchUnit.
 
 ## Do not commit
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Or run everything:
 python scripts/run_tests.py
 ```
 
-`java-pure` runs in GitHub Actions. Make it a **required** check on `main` (issue #24) so a red JVM suite cannot merge. Today branch protection requires `test (ubuntu-latest)`, `test (windows-latest)`, and `java-compile` against FTC SDK `v11.2.1`.
+`java-pure` is a **required** GitHub Actions check on `main`, along with Python `test` (Ubuntu + Windows) and `java-compile` against FTC SDK `v11.2.1`.
 
 ## Browser simulator
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Feature-level labels and maturity notes: [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DES
 | [Coordinate frames](docs/COORDINATE_FRAMES.md) | Frames, transforms, intrinsics, validation |
 | [Teaching guide](docs/TEACHING.md) | Java lessons for Control Hub development |
 | [Roadmap](docs/ROADMAP.md) | Multi-cam USB wiring, validation, optional pathing integration |
+| [Performance](docs/PERFORMANCE.md) | Hub vs desktop measurement; CI vs hardware |
 | [Pedro integration](docs/PEDRO_INTEGRATION.md) | Pose bridge + sparse tag correction with Pedro Pathing |
 | [Browser simulator](#browser-simulator) | Tune ROIs and colors before deploying to the hub |
 | [Robot templates](config/robots/README.md) | SVPRO vs C920 example `robot.json` files |
@@ -250,7 +251,7 @@ flowchart LR
 
 **Auto → TeleOp:** `spatial.close()` detaches cameras; the next OpMode's `create()` reuses the runtime and attaches fresh VisionPortals.
 
-**Local JVM tests:** `cd java-pure && ./gradlew test` (26 tests — fusion, temporal filter, tag budget, config, range fusion).
+**Local JVM tests:** `cd java-pure && ./gradlew test` (64 `@Test` methods — fusion, world association, tag budget, config, range fusion, generous throughput ceilings). Architecture guards run with `python -m pytest tests/`.
 
 Integration notes and validation checklist: [docs/ROADMAP.md](docs/ROADMAP.md).
 
@@ -267,6 +268,8 @@ Integration notes and validation checklist: [docs/ROADMAP.md](docs/ROADMAP.md).
 | [docs/CALIBRATION_CHECKLIST.md](docs/CALIBRATION_CHECKLIST.md) | Printable calibration checklist |
 | [docs/COORDINATE_FRAMES.md](docs/COORDINATE_FRAMES.md) | Frames, transforms, intrinsics |
 | [docs/TEACHING.md](docs/TEACHING.md) | Java lessons for students |
+| [docs/PERFORMANCE.md](docs/PERFORMANCE.md) | Latency budgets, measurement, CI limits |
+| [AGENTS.md](AGENTS.md) | Architecture and quality rules for humans and agents |
 | [docs/ROADMAP.md](docs/ROADMAP.md) | Phased plan and open work |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup and guidelines |
 

--- a/docs/JAVA_PACKAGE_MAP.md
+++ b/docs/JAVA_PACKAGE_MAP.md
@@ -44,4 +44,14 @@ OpMode → VidarSpatial → VidarRuntime (singleton)
 
 **Lifecycle:** `VidarSpatial.create()` → `attachVision()`; `spatial.close()` → `detachVision()`; `VidarRuntime.shutdown()` on RC exit.
 
+## Dependency direction
+
+Intended flow (high → low): OpMode / `VidarSpatial` → runtime → fusion/world → geometry/model → config types.
+
+`vidar.integration` is an adapter and may depend only on `fusion`.
+
+`vidar.geometry` and `vidar.world` must not depend on `detect`, `tag`, or `schedule`.
+
+The **current** import graph is frozen in `tests/architecture/allowed_package_edges.json`. CI fails if a new edge appears. Known cycles (frame↔detect, schedule↔runtime/detect, geometry↔fusion/runtime) are documented debt — shrink the freeze, do not grow it.
+
 See [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md) for pipeline detail.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,50 @@
+# ViDAR performance expectations
+
+ViDAR must keep Control Hub loop time **predictable**. Throughput on a desktop JVM is not the product.
+
+## Critical paths
+
+| Path | Thread | Notes |
+|------|--------|-------|
+| VisionPortal callback → `VidarFrameMailbox.publish` | Portal | Full-frame `copyTo` today |
+| Contour / tag scout `processFrame` | Portal (1-cam sync) or `VidarGlobalVisionWorker` | OpenCV; pooled Mats |
+| AprilTag crop decode | `VidarTagDecodeWorker` | Budgeted ≤ 1 Hz globally |
+| Fusion + world + snapshot | `VidarObservationWorker` (~1 ms sleep) | Holds `synchronized (VidarRuntime)` during `engine.update()` + `world.update()` |
+| Student OpMode `loop()` | Robot | Must only read snapshots; telemetry `String.format` can dominate DS loop time |
+
+## Budgets (targets, not CI gates)
+
+Record results in [validation-log.md](validation-log.md). Empty cells mean **unmeasured**.
+
+| Metric | Target | Where |
+|--------|--------|-------|
+| Element FPS / camera | ≥ 15 | Discover telemetry / `scripts/bench_metrics.py` (desktop only) |
+| Tag decode | < 400 ms when it runs | Manual OpMode |
+| Worst-case OpMode loop | Team-defined; record p50/p95/max | OpMode + `VidarMetrics` |
+| Observation worker tick | Bound fusion+world; avoid 1 kHz snapshot churn if Hub CPU is tight | Needs Hub measurement |
+
+## How to measure
+
+Desktop (not Hub):
+
+```powershell
+python scripts/bench_metrics.py
+```
+
+On the Control Hub use **ViDAR: Discover** / `VidarMetrics` (portal FPS, dropped frames, decode drops). Do not enable FTC Dashboard streaming during a MATCH (manual R704).
+
+Until #44 lands p50/p95/max, record worst-case loop time from OpMode telemetry and note firmware, camera count, and resolution.
+
+Hot-path code changes: [#40](https://github.com/The-Allsparks/ViDAR/issues/40). Measure first ([#27](https://github.com/The-Allsparks/ViDAR/issues/27)).
+
+## What CI can test
+
+- Architecture / hot-path **pattern** guards (`tests/architecture/`)
+- Generous JVM fusion/association ceilings (`RangeFusionBudgetTest`, `WorldModelBudgetTest`) — fail only on catastrophic algorithmic regression
+- Python contour sanity / desktop bench script existence
+
+## What CI cannot test
+
+Control Hub USB, GC pauses, VisionPortal callback jitter, AprilTag decode spikes, multi-camera hub contention, DS telemetry cost.
+
+Those require hardware profiling ([issue #27](https://github.com/The-Allsparks/ViDAR/issues/27), [issue #26](https://github.com/The-Allsparks/ViDAR/issues/26)).

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -161,7 +161,7 @@ Architecturally supports 1–4 cameras via `VidarVisionAttachment`. Four simulta
 
 ## JVM unit tests — **Implemented**
 
-Pure-logic tests run locally via `cd java-pure && ./gradlew test` (TagDecodeBudget, MultiCameraFusion, VidarTemporalFilter, config, range fusion). CI runs these on Ubuntu.
+Pure-logic tests run locally via `cd java-pure && ./gradlew test`. CI runs these on Ubuntu. Architecture / hot-path source guards run in the Python `test` job (`tests/architecture/`). They freeze package edges and forbid motors, `Thread.sleep` in OpModes, and `VisionPortal.Builder` outside attach. Make `java-pure` a required check on `main` ([#24](https://github.com/The-Allsparks/ViDAR/issues/24)).
 
 ## Simulator parity — **Tested in simulation**
 

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -161,7 +161,7 @@ Architecturally supports 1–4 cameras via `VidarVisionAttachment`. Four simulta
 
 ## JVM unit tests — **Implemented**
 
-Pure-logic tests run locally via `cd java-pure && ./gradlew test`. CI runs these on Ubuntu. Architecture / hot-path source guards run in the Python `test` job (`tests/architecture/`). They freeze package edges and forbid motors, `Thread.sleep` in OpModes, and `VisionPortal.Builder` outside attach. Make `java-pure` a required check on `main` ([#24](https://github.com/The-Allsparks/ViDAR/issues/24)).
+Pure-logic tests run locally via `cd java-pure && ./gradlew test`. CI runs these on Ubuntu and `java-pure` is a required check on `main`. Architecture / hot-path source guards run in the Python `test` job (`tests/architecture/`). They freeze package edges and forbid motors, `Thread.sleep` in OpModes, and `VisionPortal.Builder` outside attach.
 
 ## Simulator parity — **Tested in simulation**
 

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -34,7 +34,7 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 | **#33 FTC packaging & lifecycle** | **P0 readiness** | **Active epic** | FORGE#4 | Open | — | Hardware for USB rows | Continue children |
 | #37 Quality/CI epic | P1 | Active | This audit | Open | `chore/quality-performance-ci-baseline` | — | Merge CI PR; then children |
 | #25 Actions permissions + pins | P2 | In this PR | None | Open | same branch | — | Merge |
-| #24 java-pure required check | P2 | Ready (settings) | Admin | Open | settings | Protection API not applied here | Add `java-pure` to required checks |
+| #24 java-pure required check | P2 | **Done** | Admin | **Closed** | settings | — | `java-pure` required on `main` |
 | #38 Package cycles | P1 | Ready | #37 | Open | — | — | After CI PR |
 | #44 Metrics percentiles | P1 | Ready | #37 | Open | — | — | Unblocks honest #27/#40 |
 | #40 Tick lock / mailbox / snapshots | P1 | Ready | #44, #27 | Open | — | Measure first | After #44 |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -2,7 +2,7 @@
 
 Living ledger for orchestrator selection. GitHub issues are authoritative; this file is the in-repo snapshot.
 
-**Updated:** 2026-08-20 (post-#34)  
+**Updated:** 2026-08-20 (quality/performance/CI audit)  
 **Identity:** `TA-C-GHill`  
 **Max active implementation PRs:** 1
 
@@ -18,32 +18,38 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#29](https://github.com/The-Allsparks/ViDAR/issues/29) (first software child of [#33](https://github.com/The-Allsparks/ViDAR/issues/33)) |
-| Why highest priority | Smallest non-hardware #33 acceptance item: stop compiling against unpinned SDK tip |
-| Why ready | Tag `v11.2.1` exists; no Control Hub required |
-| Dependencies | #34 ledger sync merged (`95cedfd`) |
-| Expected deliverable | `java-compile` clones `--branch v11.2.1`; docs name the pin |
+| Selected issue | [#25](https://github.com/The-Allsparks/ViDAR/issues/25) (Actions pin + permissions) via quality CI branch |
+| Why highest priority | Lands CI hygiene already specified; architecture tests ride the same pytest job |
+| Why ready | No Control Hub required |
+| Dependencies | Quality audit children #37–#47 |
+| Expected deliverable | SHA-pinned Actions, `permissions: contents: read`, architecture guards |
 | Hardware required | No |
-| Branch | `fix/pin-ftc-sdk-java-compile` |
-| Last delivered | [#34](https://github.com/The-Allsparks/ViDAR/issues/34) via [#35](https://github.com/The-Allsparks/ViDAR/pull/35) |
+| Branch | `chore/quality-performance-ci-baseline` |
+| Last delivered | [#29](https://github.com/The-Allsparks/ViDAR/issues/29) via [#36](https://github.com/The-Allsparks/ViDAR/pull/36) |
 
 ## Ledger
 
 | Issue | Priority | Readiness | Dependencies | Status | Branch / PR | Blocker | Next action |
 |-------|----------|-----------|--------------|--------|-------------|---------|-------------|
-| **#33 FTC packaging & lifecycle** | **P0 readiness** | **Active epic** | FORGE#4 (combined) | Open | — | Hardware for USB rows | Split children; start with #29 |
-| #34 Record #33 as first priority | P0 docs | Done | #33 | **Merged** #35 `95cedfd` | — | — | Closed |
+| **#33 FTC packaging & lifecycle** | **P0 readiness** | **Active epic** | FORGE#4 | Open | — | Hardware for USB rows | Continue children |
+| #37 Quality/CI epic | P1 | Active | This audit | Open | `chore/quality-performance-ci-baseline` | — | Merge CI PR; then children |
+| #25 Actions permissions + pins | P2 | In this PR | None | Open | same branch | — | Merge |
+| #24 java-pure required check | P2 | Ready (settings) | Admin | Open | settings | Protection API not applied here | Add `java-pure` to required checks |
+| #38 Package cycles | P1 | Ready | #37 | Open | — | — | After CI PR |
+| #44 Metrics percentiles | P1 | Ready | #37 | Open | — | — | Unblocks honest #27/#40 |
+| #40 Tick lock / mailbox / snapshots | P1 | Ready | #44, #27 | Open | — | Measure first | After #44 |
+| #43 java-pure FusionEngine/Spatial | P2 | Ready | #23 partial | Open | — | — | After #38 if types move |
+| #39 God methods | P2 | Ready | — | Open | — | — | After #43 seams preferred |
+| #41 TagGate static state | P2 | Ready | — | Open | — | — | Anytime |
+| #42 JSON single tuning surface | P2 | Ready | — | Open | — | — | Anytime |
+| #45 Dedup default JSON | P3 | Ready | #42 | Open | — | — | Good first issue |
+| #46 Hide `runtime()` | P3 | Ready | — | Open | — | — | With #33 docs |
+| #47 Spotless baseline | P3 | Ready | — | Open | — | Format blast radius | Dedicated PR |
 | #19 Roadmap epic | P0 process | Active | — | Open | — | — | Keep checklist in sync |
-| #29 Pin FTC SDK in java-compile | P0 child of #33 | In progress | #33 | This PR | `fix/pin-ftc-sdk-java-compile` | — | Merge when CI green |
-| #13 Geometry-authoritative ranging | Done | Done | #17 | **Merged** #18 | — | — | Closed |
-| #20 Worker failure visibility | Done | Done | #18 | **Merged** #31 | — | — | Closed |
-| #21 Frame-gated world association | Done | Done | #20 | **Merged** #32 `e6006b0` | — | — | Closed |
-| #22 Sim range-fusion parity | P2 | Ready | #13 done | Open | — | Behind #33 gate for readiness claims | After first #33 children |
-| #23 java-pure world/runtime tests | P2 | Partial | #21 done | Open | — | — | Close or extend after review |
-| #24 java-pure required check | P2 | Ready (settings) | None | Open | — | Settings | After current PR |
-| #25 Actions permissions + pins | P2 | Ready | None | Open | — | — | After #29 or with it |
+| #22 Sim range-fusion parity | P2 | Ready | #13 done | Open | — | Behind #33 for readiness claims | After first #33 children |
+| #23 java-pure world/runtime tests | P2 | **Mostly done** | #21 done | Open | — | Remaining = #43 | Close or retarget after review |
 | #26 Hardware validation log | P1 under #33 | Blocked | Hardware | Open | — | No Control Hub | Do not invent results |
-| #27 Control Hub / desktop benches | P1 under #33 | Partial | Hardware for hub | Open | — | Hardware | Desktop OK later |
+| #27 Control Hub / desktop benches | P1 under #33 | Partial | Hardware for hub; #44 | Open | — | Hardware | Desktop OK; Hub blocked |
 | #16 Calibration visualization | P3 | Ready | #17 done | Open | — | Behind #33 | After packaging gate |
 | #14 Intrinsics quality metadata | P3 | Ready | None hard | Open | — | Behind #33 | After #16 |
 | #28 Repo hygiene templates | P4 | Ready | None | Open | — | — | After P0 children |

--- a/docs/audits/quality-performance-ci-2026-08-20.md
+++ b/docs/audits/quality-performance-ci-2026-08-20.md
@@ -1,0 +1,127 @@
+# ViDAR quality, performance, and CI audit
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-20 |
+| **Audited commit** | `b4d4f00` (`main` at start) plus this hardening branch |
+| **Repository** | [The-Allsparks/ViDAR](https://github.com/The-Allsparks/ViDAR) |
+| **Java** | TeamCode Java 11 bytecode; CI JDK 17; Gradle 8.7 |
+| **FTC SDK** | `v11.2.1` (`java-compile`) |
+| **Application refactors** | None (issues only) |
+
+This audit does not repeat the 2026-08-17 product/correctness audit. It scores **structure**, **performance readiness**, and **CI enforcement**, then adds source-level architecture guards.
+
+---
+
+## Build / test baseline (before CI edits)
+
+| Suite | Result |
+|-------|--------|
+| `python -m pytest tests/` | **PASS** — 109 tests, ~4 s |
+| `cd java-pure && ./gradlew test` | **PASS** — 62 `@Test` methods |
+| `java-compile` vs FTC SDK | Not re-run locally (clones FtcRobotController). Last merge on `main` (PR #36) was green. |
+
+After this branch: **119** pytest tests (10 architecture guards) and **64** JVM tests (two generous throughput ceilings).
+
+Compiler: `-Xlint:unchecked,deprecation` reports **3 warnings** (`WORLD_MERGE_RADIUS_IN` deprecated without `@Deprecated`, two call sites). Not `-Werror`.
+
+---
+
+## Overall structural score: **58 / 100**
+
+| Category | Score | Evidence | Strengths | Weaknesses | Most important improvement |
+|----------|------:|----------|-----------|------------|----------------------------|
+| Architecture & boundaries | 11/20 | 13 packages match `JAVA_PACKAGE_MAP`; cycles frame↔detect, schedule↔runtime/detect, geometry↔fusion/runtime; `config`→`runtime`; root dumps facade+OpModes+constants | Clear runtime vs attach split; Pedro is an adapter | Boundaries are documentation, not enforced (until this branch); camera profiles live under runtime but feed geometry | Shrink cycles; move mount/ROI types out of runtime |
+| Maintainability & readability | 8/15 | `VidarContourProcessor` ~1038 physical lines; `VidarFusionEngine.update` ~124 lines; `VidarContourTarget` ~40-arg ctor | Names generally match roles; little commented-out code | God methods; dual `VidarGeometry` / `VidarRangeFusion`; `VidarConfig` vs JSON | Split fusion tick and contour pass |
+| Dependency/state management | 8/15 | `VidarRuntime` singleton; `VidarTagGate` static volatiles; observation worker starts in runtime ctor | Atomic snapshot publish; attach/detach documented | Hidden init order; global tag gate; `runtime()` exposes internals | Runtime-owned tag gate; document/hide `runtime()` |
+| Testing & testability | 9/15 | World TTL + worker tests exist (#23 largely done); java-pure still excludes detect, FusionEngine, Spatial, most runtime | Strong geometry/fusion unit tests; Python parity | Perception stack untested on JVM; no Hub tests | Expand java-pure or seams for FusionEngine |
+| Build/repository hygiene | 7/10 | Gradle wrapper 8.7; pinned SDK; duplicate default JSON; stale excludes (removed here) | MIT; gitattributes LF | Duplicate assets; two config layers | Single JSON source of truth |
+| Static-analysis coverage | 3/10 → 6/10 after this branch | No Checkstyle/PMD/Spotless/ArchUnit. Source architecture tests added. | Targeted guards beat a noisy linter blast | No formatter; 3 deprecation warnings | Spotless later; keep architecture tests |
+| Documentation & contributor guidance | 4/5 | Excellent SYSTEM_DESIGN/API/frames; no AGENTS.md before this branch | Honest hardware-not-validated status | Stale README test count (fixed) | Keep docs matched to freeze file |
+| CI enforcement | 5/10 → 8/10 after this branch | Required: pytest + java-compile. java-pure ran but was optional (#24). No permissions/SHA pins (#25). | FTC compile job exists | Optional JVM tests; floating action tags | Require java-pure; pin actions |
+
+**Current Structural Score: 58 / 100** (functional architecture with real package cycles, weak static enforcement before this work, good docs).
+
+Classification: **Functional but quality debt exists.** A passing build does not imply isolated modules.
+
+---
+
+## Performance score: **47 / 100**
+
+| Category | Score | Evidence | Weak points | Likely impact | Confidence | Recommended measurement |
+|----------|------:|----------|-------------|---------------|------------|-------------------------|
+| Algorithmic efficiency | 14/20 | Range fusion O(1) per call; associator O(tracks×detections) with small N; MultiCameraFusion sorts small lists | FusionEngine.update does too much per 1 ms tick | Medium if track counts grow | Medium | Hub: tick time vs track count |
+| Allocation / GC | 8/20 | Pooled Mats (good). Per-frame: mailbox `copyTo`, ElementDetector ArrayList/HashMap, Scalars, snapshot ArrayLists at worker rate | Snapshot build ~1 kHz; portal-thread memcpy | **High** GC/jitter on Hub | High (static) | Allocation traces on Hub; drop worker rate |
+| Critical-path latency | 7/20 | `synchronized (VidarRuntime)` around fusion+world; OpMode `pinSnapshot` contends; 1-cam processFrame on portal thread | Unbounded wait = fusion duration | **High** loop jitter | High (static) | p50/p95 observationTick + OpMode loop |
+| Hardware / I/O | 9/15 | Scheduler disables processors before stream stop; latest-wins mailbox; tag decode budgeted | Full-frame copy every capture; DEEP_IDLE stream stop spikes | High USB/CPU | Medium | USB 2 vs 4 cam FPS; droppedFrames |
+| Concurrency | 6/10 | 3–4 threads; bounded mailboxes; workers joined on shutdown | Lock across fusion; static TagGate; 1 ms sleep wakeup | Medium CPU + contention | Medium | Thread traces; lock hold time |
+| Performance observability | 3/10 | Metrics: FPS, drops, health. No p50/p95/max tick. validation-log empty | Cannot regress what is not recorded | Blocks all Hub optimization | High | Add percentile fields |
+| Regression protection | 1/5 → 3/5 after this branch | No Hub CI. Generous JVM ceilings added. Pattern guards for sleep/portal/motors | Timing CI would be flaky | N/A | High | Keep ceilings generous |
+
+**Current Performance Score: 47 / 100** — **Significant performance risk** (unmeasured Hub path + strong static evidence of allocation/lock issues).
+
+Do not treat desktop `bench_metrics.py` ≥15 FPS as Hub proof.
+
+### Highest-risk performance findings
+
+| ID | Class | Finding |
+|----|--------|---------|
+| P-A | STRONG STATIC | `VidarFrameMailbox.publish` full-frame `copyTo` on portal thread |
+| P-B | STRONG STATIC | `observationTick` holds `synchronized (this)` for `engine.update()` + `world.update()` |
+| P-C | STRONG STATIC | Observation worker `sleepQuiet(1)` plus snapshot `build` every tick |
+| P-D | STRONG STATIC | ElementDetector / ContourDetect per-pass lists, Scalars, hit objects |
+| P-E | STRONG STATIC | OpMode `String.format` + telemetry every loop |
+| P-F | SUSPECTED | DEEP_IDLE stream stop/resume multi-10 ms USB spikes |
+| P-G | MEASURED | Desktop Python bench exists; Hub rows in validation-log are **empty** |
+
+---
+
+## CI coverage added (this branch)
+
+| Check | Prevents |
+|-------|----------|
+| `tests/architecture/test_package_boundaries.py` | New vidar package edges; hard-forbidden layering inversions |
+| `tests/architecture/test_hotpath_guards.py` | Motors/servos in ViDAR; `Thread.sleep` outside workers; `VisionPortal.Builder` outside `VidarVision`; File I/O in detect/fusion/world/geometry |
+| `tests/architecture/test_asset_parity.py` | Silent drift of duplicated default JSON |
+| `RangeFusionBudgetTest` / `WorldModelBudgetTest` | Catastrophic JVM algorithmic regression (5 s ceiling, not ms Hub budgets) |
+| Workflow `permissions: contents: read` + SHA-pinned actions | Over-privileged token; tag-moving supply chain (#25) |
+| Dependabot (actions, pip, gradle) | Stale GitHub Actions / deps without a human bump |
+| java-pure exclude comments; removed dead excludes | Mystery excludes; stale filenames |
+| `-Xlint` without `-Werror` | Visibility of deprecation/unchecked (3 existing warnings) |
+
+### Intentionally not added
+
+| Tool | Why |
+|------|-----|
+| ArchUnit | java-pure excludes most sources; TeamCode is Android/FTC |
+| Spotless / google-java-format | Would reformat ~120 files; separate baseline issue |
+| PMD / SpotBugs / Checkstyle | Noisy without a baseline; Android compatibility unclear |
+| `-Werror` | 3 existing warnings + stubs |
+| Hub millisecond performance gates | Runner noise; not a Control Hub |
+| CodeQL workflow | Repo already has CodeQL alerts; do not duplicate |
+
+### Cannot reliably test in CI
+
+Hub USB, GC, VisionPortal jitter, AprilTag decode time, 4-cam contention, DS telemetry cost. Profile on hardware; instrument `VidarMetrics`; fill validation-log.
+
+---
+
+## GitHub issues
+
+| Issue | Priority | Category | Problem | CI Detectable? |
+|-------|----------|----------|---------|----------------|
+| [#37](https://github.com/The-Allsparks/ViDAR/issues/37) | P1 | epic | Quality / performance / CI parent | Partial (guards in this PR) |
+| [#38](https://github.com/The-Allsparks/ViDAR/issues/38) | P1 | architecture | Package cycles | Yes — freeze; shrink is manual |
+| [#39](https://github.com/The-Allsparks/ViDAR/issues/39) | P2 | architecture | God methods | No (review) |
+| [#40](https://github.com/The-Allsparks/ViDAR/issues/40) | P1 | performance | Tick lock, 1 kHz snapshots, mailbox copy | Pattern only; Hub timing no |
+| [#41](https://github.com/The-Allsparks/ViDAR/issues/41) | P2 | architecture | TagGate statics | Future unit test |
+| [#42](https://github.com/The-Allsparks/ViDAR/issues/42) | P2 | architecture | Dual config surface | `-Xlint` today; more later |
+| [#43](https://github.com/The-Allsparks/ViDAR/issues/43) | P2 | testing | java-pure FusionEngine/Spatial | Yes once tests exist |
+| [#44](https://github.com/The-Allsparks/ViDAR/issues/44) | P1 | performance | Metrics percentiles | Helper unit test; not Hub |
+| [#45](https://github.com/The-Allsparks/ViDAR/issues/45) | P3 | hygiene | Duplicate default JSON | Yes — parity test now |
+| [#46](https://github.com/The-Allsparks/ViDAR/issues/46) | P3 | api | `runtime()` exposure | Optional later |
+| [#47](https://github.com/The-Allsparks/ViDAR/issues/47) | P3 | ci | Spotless baseline | Yes after format PR |
+| [#24](https://github.com/The-Allsparks/ViDAR/issues/24) | P2 | ci | Require java-pure check | Settings (not applied here) |
+| [#25](https://github.com/The-Allsparks/ViDAR/issues/25) | P2 | ci | Pin Actions + permissions | Implemented this branch |
+
+Existing issues **not duplicated**: #22 sim fusion, #23 world TTL (mostly done → #43), #26/#27 hardware benches, #28 templates, #33 packaging.

--- a/java-pure/build.gradle
+++ b/java-pure/build.gradle
@@ -10,6 +10,14 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
+tasks.withType(JavaCompile).configureEach {
+    // Surface unchecked/deprecation issues without -Werror: generated FTC stubs
+    // and Android/OpenCV types make a hard fail impractical until the exclude
+    // list shrinks. New warnings should still be treated as defects in review.
+    options.compilerArgs += ['-Xlint:unchecked', '-Xlint:deprecation']
+    options.deprecation = true
+}
+
 repositories {
     mavenCentral()
 }
@@ -27,23 +35,23 @@ sourceSets {
         java {
             srcDir 'src/stub/java'
             srcDir teamcodeVidar
+            // OpenCV VisionProcessor + Mat pipelines — need EasyOpenCV, not JVM stubs.
             exclude 'detect/**'
             exclude 'schedule/**'
             exclude '**/*OpMode.java'
-            exclude 'geometry/VidarObservationSpatial.java'
-            exclude 'geometry/VidarPoseLookup.java'
-            exclude 'geometry/VidarCalibrationDataset.java'
             exclude 'VidarTeleOp.java'
             exclude 'VidarDiscoverOpMode.java'
             exclude 'VidarAutoSeekOpMode.java'
             exclude 'VidarRoiCalibrationOpMode.java'
-            exclude 'fusion/VidarFusionEngine.java'
-            exclude 'VidarSpatial.java'
             exclude 'VidarSpatialOpModeBase.java'
-            exclude 'VidarObservationMapper.java'
+            // Spatial facade / fusion engine pull HardwareMap, VisionPortal, and excluded frame types.
+            exclude 'VidarSpatial.java'
+            exclude 'fusion/VidarFusionEngine.java'
+            exclude 'geometry/VidarObservationSpatial.java'
+            exclude 'geometry/VidarPoseLookup.java'
+            exclude 'geometry/VidarCalibrationDataset.java'
             exclude 'VidarOffensiveLane.java'
-            exclude 'VidarScoutLandmarkFix.java'
-            exclude 'VidarScoutLandmarkObservation.java'
+            // Snapshot/mailbox types need OpenCV Mat or excluded runtime cameras.
             exclude 'frame/VidarFrameMailbox.java'
             exclude 'frame/VidarFramePipeline.java'
             exclude 'frame/VidarObservationFrame.java'
@@ -52,6 +60,7 @@ sourceSets {
             exclude 'frame/VidarSpatialSnapshot.java'
             exclude 'fusion/VidarPoseBackdate.java'
             exclude 'fusion/VidarOdomHistory.java'
+            // FTC camera lifecycle — replaced by java-pure/src/stub/.../VidarVision.java for fusion tests.
             exclude 'runtime/VidarVision.java'
             exclude 'runtime/CameraPipelineConfig.java'
             exclude 'runtime/VidarRuntime.java'
@@ -65,6 +74,7 @@ sourceSets {
             exclude 'model/VidarOffensiveLaneAnalysis.java'
             exclude 'api/VidarDiagnostics.java'
             exclude 'model/VidarVisionMeasurement.java'
+            // AprilTag SDK processors.
             exclude 'tag/VidarAdaptiveTagProcessor.java'
             exclude 'tag/VidarTagDecodeWorker.java'
             exclude 'tag/VidarTagScoutRunner.java'
@@ -93,4 +103,7 @@ processResources {
 
 test {
     useJUnitPlatform()
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+    }
 }

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/geometry/RangeFusionBudgetTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/geometry/RangeFusionBudgetTest.java
@@ -1,0 +1,39 @@
+package org.firstinspires.ftc.teamcode.vidar.geometry;
+
+import org.firstinspires.ftc.teamcode.vidar.model.VidarRangeEstimate;
+import org.firstinspires.ftc.teamcode.vidar.model.VidarRangeResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Generous ceiling for JVM range-fusion throughput.
+ *
+ * <p>GitHub-hosted runners are not a Control Hub. This is not a millisecond
+ * budget — it only fails if fusion accidentally becomes catastrophically slow.
+ */
+class RangeFusionBudgetTest {
+
+    private static final int ITERATIONS = 50_000;
+    private static final long MAX_MS = 5_000;
+
+    @Test
+    void fiftyThousandThreeWayFusionsStayUnderFiveSeconds() {
+        VidarRangeEstimate size = VidarRangeFusion.buildSizeEstimate(24, 14, 0.9, false, false);
+        VidarRangeEstimate floor = VidarRangeFusion.buildFloorEstimate(25, 200, 0.8, false);
+        VidarRangeEstimate ground = VidarRangeFusion.buildGroundPlaneEstimate(24.5, 200, 0.8, false);
+
+        long start = System.nanoTime();
+        VidarRangeResult last = null;
+        for (int i = 0; i < ITERATIONS; i++) {
+            last = VidarRangeFusion.fuseRangeWeighted(size, floor, ground);
+        }
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+        assertTrue(last != null && last.isValid(), "fusion must remain valid");
+        assertTrue(
+                elapsedMs < MAX_MS,
+                "range fusion took " + elapsedMs + " ms for " + ITERATIONS
+                        + " calls; expected < " + MAX_MS + " ms (algorithmic regression)");
+    }
+}

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/world/WorldModelBudgetTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/world/WorldModelBudgetTest.java
@@ -1,0 +1,57 @@
+package org.firstinspires.ftc.teamcode.vidar.world;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Generous ceiling for world-model association. Not a Control Hub measurement.
+ */
+class WorldModelBudgetTest {
+
+    private static final int TRACKS = 24;
+    private static final int UPDATES = 400;
+    private static final long MAX_MS = 5_000;
+
+    @Test
+    void repeatedAssociationStaysUnderFiveSeconds() {
+        VidarWorldModel world = new VidarWorldModel(() -> null, null);
+        long capture = 1_000_000_000L;
+        world.updateFromDetections(detections(capture, TRACKS), capture, capture);
+
+        long start = System.nanoTime();
+        long now = capture;
+        for (int i = 1; i <= UPDATES; i++) {
+            now = capture + i * 20_000_000L;
+            world.updateFromDetections(detections(now, TRACKS), now, now);
+        }
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+        assertTrue(world.trackCount() > 0, "tracks should persist across updates");
+        assertTrue(
+                elapsedMs < MAX_MS,
+                "world association took " + elapsedMs + " ms for " + UPDATES
+                        + " updates of " + TRACKS + " detections; expected < " + MAX_MS + " ms");
+    }
+
+    private static List<VidarTrackDetection> detections(long captureNanos, int count) {
+        List<VidarTrackDetection> list = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            double x = 12.0 + i * 3.0;
+            list.add(new VidarTrackDetection(
+                    VidarWorldModel.Kind.ELEMENT,
+                    "artifact_purple",
+                    i,
+                    x,
+                    0.0,
+                    x,
+                    0.9,
+                    "Webcam 1",
+                    captureNanos));
+        }
+        return list;
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ requires-python = ">=3.11"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src", "tests/pure"]
+pythonpath = ["src", "tests", "tests/pure"]

--- a/tests/architecture/allowed_package_edges.json
+++ b/tests/architecture/allowed_package_edges.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Frozen 2026-08-20 package import graph. New edges fail CI. Removing an edge is allowed. Update this file in the same PR as an intentional new dependency, and explain why in the PR.",
+  "api": ["runtime"],
+  "config": ["root", "runtime"],
+  "detect": ["config", "frame", "fusion", "model", "root", "runtime", "schedule", "world"],
+  "frame": ["detect", "fusion", "geometry", "model", "root", "runtime", "schedule", "tag", "world"],
+  "fusion": ["config", "frame", "geometry", "model", "root", "runtime", "schedule", "tag"],
+  "geometry": ["config", "frame", "fusion", "model", "root", "runtime"],
+  "integration": ["fusion"],
+  "model": ["frame", "geometry", "root", "runtime", "tag", "world"],
+  "root": ["api", "config", "detect", "frame", "fusion", "geometry", "integration", "model", "runtime", "tag", "world"],
+  "runtime": ["api", "config", "detect", "frame", "fusion", "geometry", "model", "root", "schedule", "tag", "world"],
+  "schedule": ["detect", "frame", "root", "runtime", "tag"],
+  "tag": ["config", "detect", "frame", "model", "root", "runtime", "schedule"],
+  "world": ["frame", "fusion", "geometry", "model", "root"]
+}

--- a/tests/architecture/scan_java.py
+++ b/tests/architecture/scan_java.py
@@ -1,0 +1,74 @@
+"""Scan ViDAR TeamCode Java sources for package edges and hot-path patterns.
+
+Used by architecture tests. Does not compile Java — FTC TeamCode is source-copied
+into the SDK, and java-pure excludes most perception classes.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VIDAR_JAVA = REPO_ROOT / "teamcode" / "org" / "firstinspires" / "ftc" / "teamcode" / "vidar"
+VIDAR_PREFIX = "org.firstinspires.ftc.teamcode.vidar"
+
+IMPORT_RE = re.compile(
+    r"^import\s+(org\.firstinspires\.ftc\.teamcode\.vidar(?:\.[A-Za-z0-9_]+)*)\s*;",
+    re.MULTILINE,
+)
+
+PACKAGES = (
+    "root",
+    "api",
+    "config",
+    "detect",
+    "frame",
+    "fusion",
+    "geometry",
+    "integration",
+    "model",
+    "runtime",
+    "schedule",
+    "tag",
+    "world",
+)
+
+
+def package_of(path: Path) -> str:
+    rel = path.relative_to(VIDAR_JAVA).as_posix()
+    parts = rel.split("/")
+    if len(parts) == 1:
+        return "root"
+    return parts[0]
+
+
+def dest_package(imported: str) -> str:
+    rest = imported[len(VIDAR_PREFIX) :]
+    if not rest:
+        return "root"
+    segs = rest.lstrip(".").split(".")
+    if segs and segs[0] and segs[0][0].islower() and segs[0] in PACKAGES:
+        return segs[0]
+    return "root"
+
+
+def iter_vidar_java() -> list[Path]:
+    return sorted(VIDAR_JAVA.rglob("*.java"))
+
+
+def package_edges() -> dict[str, set[str]]:
+    edges: dict[str, set[str]] = defaultdict(set)
+    for path in iter_vidar_java():
+        src = package_of(path)
+        text = path.read_text(encoding="utf-8")
+        for match in IMPORT_RE.finditer(text):
+            dst = dest_package(match.group(1))
+            if dst != src:
+                edges[src].add(dst)
+    return edges
+
+
+def read_java(path: Path) -> str:
+    return path.read_text(encoding="utf-8")

--- a/tests/architecture/test_asset_parity.py
+++ b/tests/architecture/test_asset_parity.py
@@ -1,0 +1,31 @@
+"""Keep duplicated default JSON assets byte-identical until they are consolidated."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from architecture.scan_java import REPO_ROOT
+
+PAIRS = (
+    (
+        REPO_ROOT / "teamcode" / "assets" / "vidar" / "default-season.json",
+        REPO_ROOT / "teamcode" / "org" / "firstinspires" / "ftc" / "teamcode" / "vidar" / "config" / "bundled" / "default-season.json",
+    ),
+    (
+        REPO_ROOT / "teamcode" / "assets" / "vidar" / "default-robot.json",
+        REPO_ROOT / "teamcode" / "org" / "firstinspires" / "ftc" / "teamcode" / "vidar" / "config" / "bundled" / "default-robot.json",
+    ),
+)
+
+
+def test_bundled_default_json_copies_match():
+    mismatches = []
+    for left, right in PAIRS:
+        assert left.is_file(), f"missing {left}"
+        assert right.is_file(), f"missing {right}"
+        if left.read_bytes() != right.read_bytes():
+            mismatches.append(f"{left.name}: {left} != {right}")
+    assert not mismatches, (
+        "Default JSON copies drifted. Keep them identical or complete the "
+        "single-source consolidation issue.\n" + "\n".join(mismatches)
+    )

--- a/tests/architecture/test_hotpath_guards.py
+++ b/tests/architecture/test_hotpath_guards.py
@@ -1,0 +1,109 @@
+"""Static guards for FTC safety and Control Hub hot-path mistakes.
+
+These are not timing benchmarks. They fail when a known-bad pattern appears
+in sources that already satisfy the rule, so new debt cannot land unnoticed.
+"""
+
+from __future__ import annotations
+
+import re
+
+from architecture.scan_java import VIDAR_JAVA, iter_vidar_java, read_java
+
+MOTOR_IMPORT = re.compile(
+    r"import\s+com\.qualcomm\.robotcore\.hardware\.(DcMotor|DcMotorEx|CRServo|Servo)\s*;"
+)
+SET_POWER = re.compile(r"\.setPower\s*\(")
+SET_VELOCITY = re.compile(r"\.setVelocity\s*\(")
+THREAD_SLEEP = re.compile(r"Thread\.sleep\s*\(")
+VISION_PORTAL_BUILDER = re.compile(r"VisionPortal\.Builder")
+FILE_IO = re.compile(r"\b(FileInputStream|FileOutputStream|Files\.newBufferedReader|new\s+FileReader)\b")
+
+OPMODE_NAMES = (
+    "VidarTeleOp.java",
+    "VidarDiscoverOpMode.java",
+    "VidarAutoSeekOpMode.java",
+    "VidarRoiCalibrationOpMode.java",
+    "VidarPedroBridgeSampleOpMode.java",
+    "VidarSpatialOpModeBase.java",
+)
+
+# Thread.sleep is allowed only in background workers, never in OpModes or fusion.
+SLEEP_ALLOWED = {
+    "VidarObservationWorker.java",
+    "VidarGlobalVisionWorker.java",
+    "VidarTagDecodeWorker.java",
+}
+
+# VisionPortal construction is attach-time only.
+PORTAL_BUILDER_ALLOWED = {
+    "VidarVision.java",
+}
+
+
+def _opmode_files():
+    for path in iter_vidar_java():
+        if path.name in OPMODE_NAMES or path.name.endswith("OpMode.java"):
+            yield path
+
+
+def test_vidar_never_commands_motors_or_servos():
+    hits = []
+    for path in iter_vidar_java():
+        text = read_java(path)
+        if MOTOR_IMPORT.search(text) or SET_POWER.search(text) or SET_VELOCITY.search(text):
+            hits.append(str(path.relative_to(VIDAR_JAVA)))
+    assert not hits, (
+        "ViDAR is a passive library and must not command drivetrain or servos:\n"
+        + "\n".join(hits)
+    )
+
+
+def test_opmodes_do_not_sleep():
+    hits = []
+    for path in _opmode_files():
+        if THREAD_SLEEP.search(read_java(path)):
+            hits.append(path.name)
+    assert not hits, "OpModes must not call Thread.sleep (blocks the robot loop):\n" + "\n".join(hits)
+
+
+def test_thread_sleep_only_in_workers():
+    hits = []
+    for path in iter_vidar_java():
+        if path.name in SLEEP_ALLOWED:
+            continue
+        if THREAD_SLEEP.search(read_java(path)):
+            hits.append(path.name)
+    assert not hits, (
+        "Thread.sleep is only allowed in named worker threads, not fusion/detect/OpModes:\n"
+        + "\n".join(hits)
+    )
+
+
+def test_visionportal_builder_only_in_vidar_vision():
+    hits = []
+    for path in iter_vidar_java():
+        if path.name in PORTAL_BUILDER_ALLOWED:
+            continue
+        if VISION_PORTAL_BUILDER.search(read_java(path)):
+            hits.append(path.name)
+    assert not hits, (
+        "VisionPortal.Builder must stay in VidarVision attach/init, not per-frame update:\n"
+        + "\n".join(hits)
+    )
+
+
+def test_fusion_and_world_avoid_filesystem_io():
+    hot = ("fusion", "world", "detect", "geometry")
+    hits = []
+    for path in iter_vidar_java():
+        rel = path.relative_to(VIDAR_JAVA).as_posix()
+        pkg = rel.split("/")[0] if "/" in rel else ""
+        if pkg not in hot:
+            continue
+        if FILE_IO.search(read_java(path)):
+            hits.append(rel)
+    assert not hits, (
+        "Filesystem I/O in detect/fusion/world/geometry can stall the Control Hub:\n"
+        + "\n".join(hits)
+    )

--- a/tests/architecture/test_package_boundaries.py
+++ b/tests/architecture/test_package_boundaries.py
@@ -1,0 +1,96 @@
+"""Architecture ratchet: no new vidar package edges; never add hard-forbidden edges.
+
+These tests parse TeamCode sources (not bytecode) so they cover classes that
+java-pure excludes. ArchUnit is not used: it cannot see excluded sources, and
+the competition path is Android/FTC TeamCode rather than a JVM library module.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from architecture.scan_java import package_edges
+
+ALLOWED_PATH = Path(__file__).with_name("allowed_package_edges.json")
+
+# Edges that must never appear, even if someone edits the freeze file.
+# These currently do not exist; they would invert the intended layering.
+HARD_FORBIDDEN = {
+    ("geometry", "detect"),
+    ("geometry", "tag"),
+    ("geometry", "schedule"),
+    ("geometry", "world"),
+    ("world", "detect"),
+    ("world", "tag"),
+    ("world", "schedule"),
+    ("world", "runtime"),
+    ("integration", "detect"),
+    ("integration", "tag"),
+    ("integration", "schedule"),
+    ("integration", "runtime"),
+    ("integration", "world"),
+    ("config", "detect"),
+    ("config", "fusion"),
+    ("config", "world"),
+    ("config", "tag"),
+    ("config", "schedule"),
+    ("api", "detect"),
+    ("api", "fusion"),
+    ("api", "world"),
+    ("api", "tag"),
+    ("api", "schedule"),
+    ("api", "frame"),
+}
+
+
+def _allowed_graph() -> dict[str, set[str]]:
+    raw = json.loads(ALLOWED_PATH.read_text(encoding="utf-8"))
+    return {src: set(dsts) for src, dsts in raw.items() if not src.startswith("_")}
+
+
+def test_no_new_package_edges():
+    allowed = _allowed_graph()
+    actual = package_edges()
+    unexpected = []
+    for src, dests in sorted(actual.items()):
+        permitted = allowed.get(src, set())
+        extra = sorted(dests - permitted)
+        for dst in extra:
+            unexpected.append(f"{src} -> {dst}")
+    assert not unexpected, (
+        "New vidar package dependencies are not allowed without updating "
+        "tests/architecture/allowed_package_edges.json in the same PR.\n"
+        + "\n".join(unexpected)
+    )
+
+
+def test_hard_forbidden_package_edges_absent():
+    actual = package_edges()
+    violations = []
+    for src, dst in sorted(HARD_FORBIDDEN):
+        if dst in actual.get(src, set()):
+            violations.append(f"{src} -> {dst}")
+    assert not violations, (
+        "Forbidden layering inversion:\n" + "\n".join(violations)
+    )
+
+
+def test_freeze_file_does_not_permit_hard_forbidden_edges():
+    allowed = _allowed_graph()
+    bad = []
+    for src, dst in sorted(HARD_FORBIDDEN):
+        if dst in allowed.get(src, set()):
+            bad.append(f"{src} -> {dst}")
+    assert not bad, (
+        "allowed_package_edges.json must not whitelist hard-forbidden edges:\n"
+        + "\n".join(bad)
+    )
+
+
+def test_integration_stays_an_adapter():
+    dests = package_edges().get("integration", set())
+    assert dests <= {"fusion"}, (
+        "vidar.integration may only depend on fusion (Pedro adapter). "
+        f"Actual: {sorted(dests)}"
+    )


### PR DESCRIPTION
## Summary
- Freeze the Java package import graph and add hot-path source guards (no motors, no OpMode `Thread.sleep`, no `VisionPortal.Builder` outside attach) so new structural debt fails pytest.
- Pin GitHub Actions SHAs, set `permissions: contents: read`, and add Dependabot (Fixes #25). Generous JVM fusion/association ceilings catch catastrophic regressions only.
- Document architecture, Hub vs CI performance limits, and the 2026-08-20 quality/performance audit (scores 58 / 47). Application code is unchanged; follow-up work is #37–#47.

## Test plan
- [x] `python -m pytest tests/ -v` (119 passed locally)
- [x] `cd java-pure && ./gradlew test` (64 tests, including budget tests)
- [x] Confirm GitHub `test`, `java-compile`, and `java-pure` jobs on this PR (all green)
- [x] Add `java-pure` as a required check on `main` (#24 closed)
