### PR TITLE
Add observation-tick p50/p95/max to VidarMetrics diagnostics

### DIFF
--- a/docs/JAVA_PACKAGE_MAP.md
+++ b/docs/JAVA_PACKAGE_MAP.md
@@ -17,7 +17,7 @@
 
 | Package | Responsibility | Key classes |
 |---------|----------------|-------------|
-| `vidar.runtime` | Process runtime + camera attachment | `VidarRuntime`, `VidarVisionAttachment`, `VidarObservationWorker`, `RuntimeBootstrap`, `VidarVision`, `VidarRuntimeConfig` |
+| `vidar.runtime` | Process runtime + camera attachment | `VidarRuntime`, `VidarVisionAttachment`, `VidarObservationWorker`, `VidarLatencyWindow`, `RuntimeBootstrap`, `VidarVision`, `VidarRuntimeConfig` |
 | `vidar.api` | Student diagnostics | `VidarDiagnostics` |
 | `vidar.integration` | Optional pathing bridges (no hard deps) | `VidarPedroPose`, `VidarPedroPoseBridge`, `VidarPedroCorrectionTracker` |
 | `vidar.detect` | Contour / color-blob pipeline | `VidarContourProcessor`, `ElementDetector`, `PlateDetector` |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -20,8 +20,8 @@ Record results in [validation-log.md](validation-log.md). Empty cells mean **unm
 |--------|--------|-------|
 | Element FPS / camera | ≥ 15 | Discover telemetry / `scripts/bench_metrics.py` (desktop only) |
 | Tag decode | < 400 ms when it runs | Manual OpMode |
-| Worst-case OpMode loop | Team-defined; record p50/p95/max | OpMode + `VidarMetrics` |
-| Observation worker tick | Bound fusion+world; avoid 1 kHz snapshot churn if Hub CPU is tight | Needs Hub measurement |
+| Worst-case OpMode loop | Team-defined; record p50/p95/max | OpMode telemetry |
+| Observation worker tick | Bound fusion+world; avoid 1 kHz snapshot churn if Hub CPU is tight | Discover **Tick ms** (`diagnostics().observationTickP50Ms` / `P95` / `Max`) |
 
 ## How to measure
 
@@ -31,9 +31,21 @@ Desktop (not Hub):
 python scripts/bench_metrics.py
 ```
 
-On the Control Hub use **ViDAR: Discover** / `VidarMetrics` (portal FPS, dropped frames, decode drops). Do not enable FTC Dashboard streaming during a MATCH (manual R704).
+On the Control Hub:
 
-Until #44 lands p50/p95/max, record worst-case loop time from OpMode telemetry and note firmware, camera count, and resolution.
+1. Run **ViDAR: Discover** with the intended camera count.
+2. Read **Tick ms** — `p50`, `p95`, `max`, and sample count `n` over a ~1024-sample ring (`VidarLatencyWindow`).
+3. Also note portal FPS, dropped frames, and decode drops from `VidarMetrics`.
+4. Paste numbers into [validation-log.md](validation-log.md) with firmware, camera count, and resolution.
+
+Do not enable FTC Dashboard streaming during a MATCH (manual R704).
+
+The same tick percentiles are on `VidarSpatial.diagnostics()` after each `update()`:
+
+```java
+VidarDiagnostics d = spatial.diagnostics();
+// d.observationTickP50Ms / P95Ms / MaxMs / Samples
+```
 
 Hot-path code changes: [#40](https://github.com/The-Allsparks/ViDAR/issues/40). Measure first ([#27](https://github.com/The-Allsparks/ViDAR/issues/27)).
 

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -18,14 +18,14 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#25](https://github.com/The-Allsparks/ViDAR/issues/25) (Actions pin + permissions) via quality CI branch |
-| Why highest priority | Lands CI hygiene already specified; architecture tests ride the same pytest job |
-| Why ready | No Control Hub required |
-| Dependencies | Quality audit children #37–#47 |
-| Expected deliverable | SHA-pinned Actions, `permissions: contents: read`, architecture guards |
-| Hardware required | No |
-| Branch | `chore/quality-performance-ci-baseline` |
-| Last delivered | [#29](https://github.com/The-Allsparks/ViDAR/issues/29) via [#36](https://github.com/The-Allsparks/ViDAR/pull/36) |
+| Selected issue | [#44](https://github.com/The-Allsparks/ViDAR/issues/44) (observation-tick percentiles) |
+| Why highest priority | Unblocks honest Hub measurement for #27 / #40 |
+| Why ready | No Control Hub required for the code; Hub fills validation-log later |
+| Dependencies | #37 epic; #48 CI baseline merged |
+| Expected deliverable | `VidarLatencyWindow` + Discover **Tick ms** + PERFORMANCE.md procedure |
+| Hardware required | No for code; Hub for filling log |
+| Branch | `feat/observation-tick-latency-metrics` |
+| Last delivered | [#25](https://github.com/The-Allsparks/ViDAR/issues/25) / [#24](https://github.com/The-Allsparks/ViDAR/issues/24) via [#48](https://github.com/The-Allsparks/ViDAR/pull/48) |
 
 ## Ledger
 
@@ -36,7 +36,7 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 | #25 Actions permissions + pins | P2 | In this PR | None | Open | same branch | — | Merge |
 | #24 java-pure required check | P2 | **Done** | Admin | **Closed** | settings | — | `java-pure` required on `main` |
 | #38 Package cycles | P1 | Ready | #37 | Open | — | — | After CI PR |
-| #44 Metrics percentiles | P1 | Ready | #37 | Open | — | — | Unblocks honest #27/#40 |
+| #44 Metrics percentiles | P1 | **In progress** | #37 | Open | `feat/observation-tick-latency-metrics` | — | Land PR |
 | #40 Tick lock / mailbox / snapshots | P1 | Ready | #44, #27 | Open | — | Measure first | After #44 |
 | #43 java-pure FusionEngine/Spatial | P2 | Ready | #23 partial | Open | — | — | After #38 if types move |
 | #39 God methods | P2 | Ready | — | Open | — | — | After #43 seams preferred |

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/runtime/VidarLatencyWindowTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/runtime/VidarLatencyWindowTest.java
@@ -1,0 +1,76 @@
+package org.firstinspires.ftc.teamcode.vidar.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VidarLatencyWindowTest {
+
+    @Test
+    void emptyWindowReportsZeros() {
+        VidarLatencyWindow window = new VidarLatencyWindow(8);
+        assertEquals(0, window.sampleCount());
+        assertEquals(0.0, window.p50Ms(), 1e-9);
+        assertEquals(0.0, window.p95Ms(), 1e-9);
+        assertEquals(0.0, window.maxMs(), 1e-9);
+    }
+
+    @Test
+    void rejectsNonPositiveCapacity() {
+        assertThrows(IllegalArgumentException.class, () -> new VidarLatencyWindow(0));
+    }
+
+    @Test
+    void percentilesMatchSortedSeries() {
+        VidarLatencyWindow window = new VidarLatencyWindow(16);
+        // 1..20 ms as nanoseconds (only last 16 kept once capacity fills).
+        for (int ms = 1; ms <= 20; ms++) {
+            window.record(ms * 1_000_000L);
+        }
+        assertEquals(16, window.sampleCount());
+        // Window holds 5..20 ms. p50 → ceil(0.5*16)-1 = 7 → 12 ms; p95 → ceil(0.95*16)-1 = 15 → 20 ms.
+        assertEquals(12.0, window.p50Ms(), 1e-9);
+        assertEquals(20.0, window.p95Ms(), 1e-9);
+        assertEquals(20.0, window.maxMs(), 1e-9);
+    }
+
+    @Test
+    void clampsNegativeSamples() {
+        VidarLatencyWindow window = new VidarLatencyWindow(4);
+        window.record(-5_000_000L);
+        window.record(2_000_000L);
+        assertEquals(0.0, window.percentileMs(0.0), 1e-9);
+        assertEquals(2.0, window.maxMs(), 1e-9);
+    }
+
+    @Test
+    void clearResetsWindow() {
+        VidarLatencyWindow window = new VidarLatencyWindow(4);
+        window.record(3_000_000L);
+        window.clear();
+        assertEquals(0, window.sampleCount());
+        assertEquals(0.0, window.maxMs(), 1e-9);
+    }
+
+    @Test
+    void recordDoesNotAllocateBeyondConstruction() {
+        VidarLatencyWindow window = new VidarLatencyWindow(64);
+        Runtime runtime = Runtime.getRuntime();
+        runtime.gc();
+        long before = usedHeap(runtime);
+        for (int i = 0; i < 10_000; i++) {
+            window.record(i);
+        }
+        long after = usedHeap(runtime);
+        // Generous: recording must not create thousands of objects. Allow a few MB of noise.
+        assertTrue(after - before < 2_000_000L,
+                "record() heap delta too large: " + (after - before) + " bytes");
+        assertEquals(64, window.sampleCount());
+    }
+
+    private static long usedHeap(Runtime runtime) {
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarDiscoverOpMode.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarDiscoverOpMode.java
@@ -72,6 +72,14 @@ public class VidarDiscoverOpMode extends VidarSpatialOpModeBase {
                         + (spatial.diagnostics().observationWorkerLastError.isEmpty()
                                 ? "" : ": " + spatial.diagnostics().observationWorkerLastError));
             }
+            if (spatial.diagnostics().observationTickSamples > 0) {
+                telemetry.addData("Tick ms", String.format(
+                        "p50=%.2f p95=%.2f max=%.2f n=%d",
+                        spatial.diagnostics().observationTickP50Ms,
+                        spatial.diagnostics().observationTickP95Ms,
+                        spatial.diagnostics().observationTickMaxMs,
+                        spatial.diagnostics().observationTickSamples));
+            }
             telemetry.addData("FPS cam1", spatial.cameraCount() > 0
                     && spatial.runtime().camera(0) != null
                     ? String.format("%.1f", spatial.runtime().camera(0).portalFps()) : "—");

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/VidarSpatial.java
@@ -7,6 +7,7 @@ import org.firstinspires.ftc.teamcode.vidar.frame.VidarSpatialSnapshot;
 import org.firstinspires.ftc.teamcode.vidar.fusion.VidarFusionEngine;
 import org.firstinspires.ftc.teamcode.vidar.model.VidarOffensiveLaneAnalysis;
 import org.firstinspires.ftc.teamcode.vidar.runtime.RuntimeBootstrap;
+import org.firstinspires.ftc.teamcode.vidar.runtime.VidarLatencyWindow;
 import org.firstinspires.ftc.teamcode.vidar.runtime.VidarObservationWorker;
 import org.firstinspires.ftc.teamcode.vidar.runtime.VidarRuntime;
 import com.qualcomm.robotcore.hardware.HardwareMap;
@@ -324,8 +325,11 @@ public final class VidarSpatial {
                     + " consecutive=" + workerConsecutive
                     + (workerError.isEmpty() ? "" : ": " + workerError));
         }
+        VidarLatencyWindow tickLatency = runtime.observationTickLatency();
         diagnostics = new VidarDiagnostics(
                 runtime.configSource(), count, connected, warnings, health,
-                workerError, workerConsecutive, workerTotal);
+                workerError, workerConsecutive, workerTotal,
+                tickLatency.p50Ms(), tickLatency.p95Ms(), tickLatency.maxMs(),
+                tickLatency.sampleCount());
     }
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/api/VidarDiagnostics.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/api/VidarDiagnostics.java
@@ -27,6 +27,11 @@ public final class VidarDiagnostics {
     public final String observationWorkerLastError;
     public final int observationWorkerConsecutiveFailures;
     public final int observationWorkerTotalFailures;
+    /** Observation-worker tick latency percentiles over a recent window (milliseconds). */
+    public final double observationTickP50Ms;
+    public final double observationTickP95Ms;
+    public final double observationTickMaxMs;
+    public final int observationTickSamples;
 
     public VidarDiagnostics(
             ConfigSource configSource,
@@ -34,7 +39,7 @@ public final class VidarDiagnostics {
             int connectedCameras,
             List<String> warnings,
             VidarMetrics.CameraHealth[] cameraHealth) {
-        this(configSource, cameraCount, connectedCameras, warnings, cameraHealth, "", 0, 0);
+        this(configSource, cameraCount, connectedCameras, warnings, cameraHealth, "", 0, 0, 0, 0, 0, 0);
     }
 
     public VidarDiagnostics(
@@ -46,6 +51,34 @@ public final class VidarDiagnostics {
             String observationWorkerLastError,
             int observationWorkerConsecutiveFailures,
             int observationWorkerTotalFailures) {
+        this(
+                configSource,
+                cameraCount,
+                connectedCameras,
+                warnings,
+                cameraHealth,
+                observationWorkerLastError,
+                observationWorkerConsecutiveFailures,
+                observationWorkerTotalFailures,
+                0,
+                0,
+                0,
+                0);
+    }
+
+    public VidarDiagnostics(
+            ConfigSource configSource,
+            int cameraCount,
+            int connectedCameras,
+            List<String> warnings,
+            VidarMetrics.CameraHealth[] cameraHealth,
+            String observationWorkerLastError,
+            int observationWorkerConsecutiveFailures,
+            int observationWorkerTotalFailures,
+            double observationTickP50Ms,
+            double observationTickP95Ms,
+            double observationTickMaxMs,
+            int observationTickSamples) {
         this.configSource = configSource;
         this.cameraCount = cameraCount;
         this.connectedCameras = connectedCameras;
@@ -57,6 +90,10 @@ public final class VidarDiagnostics {
                 observationWorkerLastError == null ? "" : observationWorkerLastError;
         this.observationWorkerConsecutiveFailures = observationWorkerConsecutiveFailures;
         this.observationWorkerTotalFailures = observationWorkerTotalFailures;
+        this.observationTickP50Ms = observationTickP50Ms;
+        this.observationTickP95Ms = observationTickP95Ms;
+        this.observationTickMaxMs = observationTickMaxMs;
+        this.observationTickSamples = observationTickSamples;
     }
 
     public static VidarDiagnostics empty() {
@@ -76,6 +113,11 @@ public final class VidarDiagnostics {
         }
         if (observationWorkerTotalFailures > 0) {
             sb.append(" workerFailures=").append(observationWorkerTotalFailures);
+        }
+        if (observationTickSamples > 0) {
+            sb.append(" tickMs p50=").append(String.format("%.2f", observationTickP50Ms));
+            sb.append(" p95=").append(String.format("%.2f", observationTickP95Ms));
+            sb.append(" max=").append(String.format("%.2f", observationTickMaxMs));
         }
         return sb.toString();
     }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarLatencyWindow.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarLatencyWindow.java
@@ -1,0 +1,94 @@
+package org.firstinspires.ftc.teamcode.vidar.runtime;
+
+import java.util.Arrays;
+
+/**
+ * Fixed-capacity ring of latency samples with O(1) record and reused scratch for percentiles.
+ *
+ * <p>No per-sample allocation. Query methods sort a preallocated scratch copy — call them at
+ * telemetry rates, not inside every vision callback.
+ */
+public final class VidarLatencyWindow {
+
+    private final long[] samples;
+    private final long[] scratch;
+    private int next;
+    private int count;
+
+    public VidarLatencyWindow(int capacity) {
+        if (capacity < 1) {
+            throw new IllegalArgumentException("capacity must be >= 1");
+        }
+        this.samples = new long[capacity];
+        this.scratch = new long[capacity];
+    }
+
+    /** Record a duration in nanoseconds (negative values are clamped to 0). */
+    public synchronized void record(long durationNanos) {
+        long value = durationNanos < 0L ? 0L : durationNanos;
+        samples[next] = value;
+        next = (next + 1) % samples.length;
+        if (count < samples.length) {
+            count++;
+        }
+    }
+
+    public synchronized int sampleCount() {
+        return count;
+    }
+
+    public synchronized void clear() {
+        next = 0;
+        count = 0;
+        Arrays.fill(samples, 0L);
+    }
+
+    /** Median of the current window in milliseconds, or 0 if empty. */
+    public double p50Ms() {
+        return percentileMs(0.50);
+    }
+
+    /** 95th percentile of the current window in milliseconds, or 0 if empty. */
+    public double p95Ms() {
+        return percentileMs(0.95);
+    }
+
+    /** Maximum sample in the current window in milliseconds, or 0 if empty. */
+    public synchronized double maxMs() {
+        if (count == 0) {
+            return 0.0;
+        }
+        long max = samples[0];
+        for (int i = 1; i < count; i++) {
+            if (samples[i] > max) {
+                max = samples[i];
+            }
+        }
+        return max / 1_000_000.0;
+    }
+
+    /**
+     * Percentile in {@code [0, 1]} over the current window, returned in milliseconds.
+     * Empty window returns 0.
+     */
+    public synchronized double percentileMs(double percentile) {
+        if (count == 0) {
+            return 0.0;
+        }
+        double p = percentile;
+        if (p < 0.0) {
+            p = 0.0;
+        } else if (p > 1.0) {
+            p = 1.0;
+        }
+        System.arraycopy(samples, 0, scratch, 0, count);
+        Arrays.sort(scratch, 0, count);
+        int index = (int) Math.ceil(p * count) - 1;
+        if (index < 0) {
+            index = 0;
+        } else if (index >= count) {
+            index = count - 1;
+        }
+        return scratch[index] / 1_000_000.0;
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
@@ -36,12 +36,17 @@ public final class VidarRuntime {
     private static final Object LOCK = new Object();
     private static volatile VidarRuntime instance;
 
+    /** ~1 s of samples at a 1 ms observation-worker period; oversized if the tick slows. */
+    private static final int OBSERVATION_TICK_WINDOW = 1024;
+
     private final VidarWorldModel world;
     private final FieldPoseContext fieldPoseContext;
     private final TagDecodeBudget tagDecodeBudget;
     private final VidarTagDecodeWorker tagDecodeWorker;
     private final VidarResourceBudget resourceBudget;
     private final VidarObservationWorker observationWorker;
+    private final VidarLatencyWindow observationTickLatency =
+            new VidarLatencyWindow(OBSERVATION_TICK_WINDOW);
     private final AtomicReference<VidarSpatialSnapshot> publishedSnapshot =
             new AtomicReference<>(VidarSpatialSnapshot.empty());
     private final AtomicReference<VidarObservationFrame> publishedFrame =
@@ -243,6 +248,11 @@ public final class VidarRuntime {
         return observationWorker;
     }
 
+    /** Recent observation-worker tick latencies (p50/p95/max). Safe to read from the OpMode loop. */
+    public VidarLatencyWindow observationTickLatency() {
+        return observationTickLatency;
+    }
+
     public VidarGlobalVisionWorker globalVisionWorker() {
         return attachment == null ? null : attachment.globalVisionWorker();
     }
@@ -270,23 +280,28 @@ public final class VidarRuntime {
     }
 
     private void observationTick() {
-        VidarFusionEngine engine;
-        synchronized (this) {
-            engine = fusionEngine;
-            if (engine != null) {
-                if (fieldPoseContext.odomSupplier() != null) {
-                    engine.recordOdom(fieldPoseContext.odomSupplier().get());
+        long startedNanos = System.nanoTime();
+        try {
+            VidarFusionEngine engine;
+            synchronized (this) {
+                engine = fusionEngine;
+                if (engine != null) {
+                    if (fieldPoseContext.odomSupplier() != null) {
+                        engine.recordOdom(fieldPoseContext.odomSupplier().get());
+                    }
+                    engine.update();
+                    world.update(engine, System.nanoTime());
+                } else {
+                    world.update(null, System.nanoTime());
                 }
-                engine.update();
-                world.update(engine, System.nanoTime());
-            } else {
-                world.update(null, System.nanoTime());
             }
-        }
-        if (engine != null) {
-            publishNow();
-        } else {
-            publishDetachedSnapshot();
+            if (engine != null) {
+                publishNow();
+            } else {
+                publishDetachedSnapshot();
+            }
+        } finally {
+            observationTickLatency.record(System.nanoTime() - startedNanos);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `VidarLatencyWindow` (fixed ring, no per-sample allocation) and record every `observationTick` in `VidarRuntime`.
- Expose p50 / p95 / max / sample count on `VidarDiagnostics` and **ViDAR: Discover** `Tick ms` telemetry.
- Document Hub measurement procedure in `docs/PERFORMANCE.md`. JVM unit tests cover percentiles and empty/clear behavior.

Fixes #44

## Test plan
- [x] `cd java-pure && ./gradlew test` (includes `VidarLatencyWindowTest`)
- [x] `python -m pytest tests/architecture -q`
- [ ] On Hub: run Discover, confirm `Tick ms` line updates; paste into validation-log when ready (#27)
