### PR TITLE
Break frame→detect package cycle and shrink import freeze

### DIFF
--- a/docs/JAVA_PACKAGE_MAP.md
+++ b/docs/JAVA_PACKAGE_MAP.md
@@ -52,6 +52,6 @@ Intended flow (high → low): OpMode / `VidarSpatial` → runtime → fusion/wor
 
 `vidar.geometry` and `vidar.world` must not depend on `detect`, `tag`, or `schedule`.
 
-The **current** import graph is frozen in `tests/architecture/allowed_package_edges.json`. CI fails if a new edge appears. Known cycles (frame↔detect, schedule↔runtime/detect, geometry↔fusion/runtime) are documented debt — shrink the freeze, do not grow it.
+The **current** import graph is frozen in `tests/architecture/allowed_package_edges.json`. CI fails if a new edge appears. Known remaining cycles (schedule↔runtime/detect, geometry↔fusion/runtime) are documented debt — shrink the freeze, do not grow it. The former `frame`↔`detect` cycle was removed (frame no longer imports detect).
 
 See [SYSTEM_DESIGN.md](SYSTEM_DESIGN.md) for pipeline detail.

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -18,14 +18,14 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#44](https://github.com/The-Allsparks/ViDAR/issues/44) (observation-tick percentiles) |
-| Why highest priority | Unblocks honest Hub measurement for #27 / #40 |
-| Why ready | No Control Hub required for the code; Hub fills validation-log later |
-| Dependencies | #37 epic; #48 CI baseline merged |
-| Expected deliverable | `VidarLatencyWindow` + Discover **Tick ms** + PERFORMANCE.md procedure |
-| Hardware required | No for code; Hub for filling log |
-| Branch | `feat/observation-tick-latency-metrics` |
-| Last delivered | [#25](https://github.com/The-Allsparks/ViDAR/issues/25) / [#24](https://github.com/The-Allsparks/ViDAR/issues/24) via [#48](https://github.com/The-Allsparks/ViDAR/pull/48) |
+| Selected issue | [#38](https://github.com/The-Allsparks/ViDAR/issues/38) (break package cycles) |
+| Why highest priority | Shrinks the import freeze after #44 measurement landed |
+| Why ready | frame→detect was javadoc-only; no Control Hub required |
+| Dependencies | #37 epic; #44 done |
+| Expected deliverable | Remove `frame`→`detect` from freeze; architecture tests green |
+| Hardware required | No |
+| Branch | `refactor/break-frame-detect-package-cycle` |
+| Last delivered | [#44](https://github.com/The-Allsparks/ViDAR/issues/44) via [#59](https://github.com/The-Allsparks/ViDAR/pull/59) |
 
 ## Ledger
 
@@ -35,8 +35,8 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 | #37 Quality/CI epic | P1 | Active | This audit | Open | `chore/quality-performance-ci-baseline` | — | Merge CI PR; then children |
 | #25 Actions permissions + pins | P2 | In this PR | None | Open | same branch | — | Merge |
 | #24 java-pure required check | P2 | **Done** | Admin | **Closed** | settings | — | `java-pure` required on `main` |
-| #38 Package cycles | P1 | Ready | #37 | Open | — | — | After CI PR |
-| #44 Metrics percentiles | P1 | **In progress** | #37 | Open | `feat/observation-tick-latency-metrics` | — | Land PR |
+| #38 Package cycles | P1 | **In progress** | #37 | Open | `refactor/break-frame-detect-package-cycle` | — | Land frame→detect removal |
+| #44 Metrics percentiles | P1 | **Done** | #37 | **Closed** #59 | — | — | Discover Tick ms |
 | #40 Tick lock / mailbox / snapshots | P1 | Ready | #44, #27 | Open | — | Measure first | After #44 |
 | #43 java-pure FusionEngine/Spatial | P2 | Ready | #23 partial | Open | — | — | After #38 if types move |
 | #39 God methods | P2 | Ready | — | Open | — | — | After #43 seams preferred |

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/frame/VidarFramePipeline.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/frame/VidarFramePipeline.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.teamcode.vidar.frame;
 
-import org.firstinspires.ftc.teamcode.vidar.detect.VidarContourProcessor;
 import org.firstinspires.ftc.teamcode.vidar.runtime.VidarCameraProfile;
 import org.firstinspires.ftc.teamcode.vidar.runtime.VidarRoiRect;
 import org.opencv.core.Mat;
@@ -90,7 +89,7 @@ public final class VidarFramePipeline {
         return roiScaled(frame, roi, scale);
     }
 
-    /** Shared element + plate ROI for {@link VidarContourProcessor}. */
+    /** Shared element + plate ROI for the unified contour detection pass. */
     public static ScaledRoi detectionScaled(Mat frame, VidarCameraProfile profile, double scale) {
         VidarRoiRect roi = VidarFrameRegions.detectionRoi(profile, frame.cols(), frame.rows());
         return roiScaled(frame, roi, scale);

--- a/tests/architecture/allowed_package_edges.json
+++ b/tests/architecture/allowed_package_edges.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "Frozen 2026-08-20 package import graph. New edges fail CI. Removing an edge is allowed. Update this file in the same PR as an intentional new dependency, and explain why in the PR.",
+  "_comment": "Frozen 2026-08-20 package import graph; shrunk 2026-08-21 (removed frame→detect). New edges fail CI. Removing an edge is allowed. Update this file in the same PR as an intentional new dependency, and explain why in the PR.",
   "api": ["runtime"],
   "config": ["root", "runtime"],
   "detect": ["config", "frame", "fusion", "model", "root", "runtime", "schedule", "world"],
-  "frame": ["detect", "fusion", "geometry", "model", "root", "runtime", "schedule", "tag", "world"],
+  "frame": ["fusion", "geometry", "model", "root", "runtime", "schedule", "tag", "world"],
   "fusion": ["config", "frame", "geometry", "model", "root", "runtime", "schedule", "tag"],
   "geometry": ["config", "frame", "fusion", "model", "root", "runtime"],
   "integration": ["fusion"],


### PR DESCRIPTION
## Summary
- Remove the unused `VidarContourProcessor` import from `VidarFramePipeline` (javadoc-only).
- Drop `frame` → `detect` from `tests/architecture/allowed_package_edges.json` so the cycle cannot return unnoticed.
- Update package-map / ledger notes. Remaining cycles (schedule↔runtime/detect, geometry↔fusion/runtime) stay documented debt for follow-ups.

Fixes #38

## Test plan
- [x] `python -m pytest tests/architecture -v`
- [ ] Confirm GitHub `test` / `java-compile` / `java-pure` on this PR
