### PR TITLE
Expand java-pure fusion camera-skip seam tests (#43)

### DIFF
--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -2,7 +2,7 @@
 
 Living ledger for orchestrator selection. GitHub issues are authoritative; this file is the in-repo snapshot.
 
-**Updated:** 2026-08-20 (quality/performance/CI audit)  
+**Updated:** 2026-08-21 (after #60/#61; #43 in progress)  
 **Identity:** `TA-C-GHill`  
 **Max active implementation PRs:** 1
 
@@ -18,35 +18,36 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#33](https://github.com/The-Allsparks/ViDAR/issues/33) install/lifecycle docs slice |
-| Why highest priority | P0 FTC packaging; SDK pin done; Hub rows blocked |
-| Why ready | Docs + VERSION + architecture guards; no Control Hub |
-| Dependencies | #29 done; #38/#44 done |
-| Expected deliverable | `VERSION`, `docs/INSTALL.md`, `docs/LIFECYCLE.md`, OpMode `close()` CI guard |
+| Selected issue | [#43](https://github.com/The-Allsparks/ViDAR/issues/43) java-pure fusion/lifecycle seams |
+| Why highest priority | Unblocks god-method refactors; CI must catch failed-camera skip regressions |
+| Why ready | #38/#61 on main; WorldModel null-coast already covered |
+| Dependencies | #23 partial (TTL done) |
+| Expected deliverable | `MultiCameraFusion.isUsableCamera` + JVM skip tests; FusionEngine exclude stays |
 | Hardware required | No |
-| Branch | `docs/ftc-install-and-lifecycle-gate` |
-| Last delivered | [#38](https://github.com/The-Allsparks/ViDAR/issues/38) via [#60](https://github.com/The-Allsparks/ViDAR/pull/60) |
+| Branch | `test/java-pure-fusion-lifecycle-seams` |
+| Last delivered | [#33](https://github.com/The-Allsparks/ViDAR/issues/33) docs slice via [#61](https://github.com/The-Allsparks/ViDAR/pull/61) |
 
 ## Ledger
 
 | Issue | Priority | Readiness | Dependencies | Status | Branch / PR | Blocker | Next action |
 |-------|----------|-----------|--------------|--------|-------------|---------|-------------|
-| **#33 FTC packaging & lifecycle** | **P0 readiness** | **Active epic** | FORGE#4 | Open | — | Hardware for USB rows | Continue children |
+| **#33 FTC packaging & lifecycle** | **P0 readiness** | **Active epic** | FORGE#4 | Open | — | Hardware for USB rows | Hub/#26/#27 next software |
 | #38 Package cycles | P1 | **Done** | #37 | **Closed** #60 | — | — | frame→detect removed |
+| #61 Install/lifecycle docs | P0 under #33 | **Done** | #33 | **Merged** | — | — | VERSION + close() guard |
 | #37 Quality/CI epic | P1 | Active | This audit | Open | — | — | Children remain |
 | #25 Actions permissions + pins | P2 | **Done** | None | **Closed** #48 | — | — | SHA pins |
 | #44 Metrics percentiles | P1 | **Done** | #37 | **Closed** #59 | — | — | Discover Tick ms |
-| #40 Tick lock / mailbox / snapshots | P1 | Ready | #44, #27 | Open | — | Measure first | After #44 |
-| #43 java-pure FusionEngine/Spatial | P2 | Ready | #23 partial | Open | — | — | After #38 if types move |
+| #40 Tick lock / mailbox / snapshots | P1 | Ready | #44, #27 | Open | — | Measure first | After #27 Hub/desktop |
+| #43 java-pure FusionEngine/Spatial | P2 | **Active** | #23 partial | Open | `test/java-pure-fusion-lifecycle-seams` | — | Land seam tests |
+| #41 TagGate static state | P2 | Ready | — | Open | — | — | After #43 |
+| #42 JSON single tuning surface | P2 | Ready | — | Open | — | — | After #43 / with #41 |
 | #39 God methods | P2 | Ready | — | Open | — | — | After #43 seams preferred |
-| #41 TagGate static state | P2 | Ready | — | Open | — | — | Anytime |
-| #42 JSON single tuning surface | P2 | Ready | — | Open | — | — | Anytime |
 | #45 Dedup default JSON | P3 | Ready | #42 | Open | — | — | Good first issue |
 | #46 Hide `runtime()` | P3 | Ready | — | Open | — | — | With #33 docs |
 | #47 Spotless baseline | P3 | Ready | — | Open | — | Format blast radius | Dedicated PR |
 | #19 Roadmap epic | P0 process | Active | — | Open | — | — | Keep checklist in sync |
-| #22 Sim range-fusion parity | P2 | Ready | #13 done | Open | — | Behind #33 for readiness claims | After first #33 children |
-| #23 java-pure world/runtime tests | P2 | **Mostly done** | #21 done | Open | — | Remaining = #43 | Close or retarget after review |
+| #22 Sim range-fusion parity | P2 | Ready | #13 done | Open | — | Behind #33 for readiness claims | After #41/#42 |
+| #23 java-pure world/runtime tests | P2 | **Mostly done** | #21 done | Open | — | Remaining = #43 | Close after #43 |
 | #26 Hardware validation log | P1 under #33 | Blocked | Hardware | Open | — | No Control Hub | Do not invent results |
 | #27 Control Hub / desktop benches | P1 under #33 | Partial | Hardware for hub; #44 | Open | — | Hardware | Desktop OK; Hub blocked |
 | #16 Calibration visualization | P3 | Ready | #17 done | Open | — | Behind #33 | After packaging gate |

--- a/java-pure/build.gradle
+++ b/java-pure/build.gradle
@@ -45,6 +45,7 @@ sourceSets {
             exclude 'VidarRoiCalibrationOpMode.java'
             exclude 'VidarSpatialOpModeBase.java'
             // Spatial facade / fusion engine pull HardwareMap, VisionPortal, and excluded frame types.
+            // Fusion camera-skip seams are covered via MultiCameraFusion.isUsableCamera (used by update()).
             exclude 'VidarSpatial.java'
             exclude 'fusion/VidarFusionEngine.java'
             exclude 'geometry/VidarObservationSpatial.java'

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/fusion/MultiCameraFusionTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/fusion/MultiCameraFusionTest.java
@@ -8,6 +8,7 @@ import org.firstinspires.ftc.teamcode.vidar.runtime.VidarVision;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MultiCameraFusionTest {
@@ -20,23 +21,67 @@ class MultiCameraFusionTest {
     }
 
     @Test
+    void isUsableCameraRejectsNullFailedAndExcluded() {
+        assertFalse(MultiCameraFusion.isUsableCamera(null));
+
+        VidarVision ok = cameraWith(obs(0.9, 100, 12, 5, 5));
+        assertTrue(MultiCameraFusion.isUsableCamera(ok));
+
+        VidarVision failed = cameraWith(obs(0.9, 100, 12, 5, 5));
+        failed.setFailed(true);
+        assertFalse(MultiCameraFusion.isUsableCamera(failed));
+
+        VidarVision excluded = cameraWith(obs(0.9, 100, 12, 5, 5));
+        excluded.setExcludedFromRotation(true);
+        assertFalse(MultiCameraFusion.isUsableCamera(excluded));
+    }
+
+    @Test
     void fuseRankedElementsDedupesNearbyDetections() {
         VidarTemporalFilter filter = new VidarTemporalFilter();
         VidarElementObservation a = obs(0.95, 100, 12, 10, 10);
         VidarElementObservation b = obs(0.9, 100, 14, 10.5, 10.2);
 
-        VidarElementObservation[] rankedA = new VidarElementObservation[8];
-        rankedA[0] = a;
-        VidarElementObservation[] rankedB = new VidarElementObservation[8];
-        rankedB[0] = b;
-        VidarVision cam0 = new VidarVision(new VidarRankedElementFrame(rankedA, 1, 0, 1, "cam0", 8));
-        VidarVision cam1 = new VidarVision(new VidarRankedElementFrame(rankedB, 1, 0, 2, "cam1", 8));
+        VidarVision cam0 = cameraWith(a);
+        VidarVision cam1 = cameraWith(b);
         VidarVision[] cameras = {cam0, cam1};
 
         VidarRankedElementFrame fused = MultiCameraFusion.fuseRankedElements(
                 cameras, filter, VidarConfig.FUSION_MAX_RANKED_ELEMENTS);
         assertEquals(1, fused.count());
         assertEquals(0, fused.overflowCount());
+    }
+
+    @Test
+    void fuseRankedElementsSkipsFailedCameras() {
+        VidarTemporalFilter filter = new VidarTemporalFilter();
+        VidarVision healthy = cameraWith(obs(0.9, 100, 12, 20, 0));
+        VidarVision failed = cameraWith(obs(0.99, 200, 8, 0, 20));
+        failed.setFailed(true);
+
+        VidarRankedElementFrame fused = MultiCameraFusion.fuseRankedElements(
+                new VidarVision[] {healthy, failed}, filter, VidarConfig.FUSION_MAX_RANKED_ELEMENTS);
+        assertEquals(1, fused.count());
+        assertEquals(20.0, fused.at(0).robotX, 1e-9);
+    }
+
+    @Test
+    void fuseRankedElementsSkipsExcludedCameras() {
+        VidarTemporalFilter filter = new VidarTemporalFilter();
+        VidarVision healthy = cameraWith(obs(0.9, 100, 12, 20, 0));
+        VidarVision excluded = cameraWith(obs(0.99, 200, 8, 0, 20));
+        excluded.setExcludedFromRotation(true);
+
+        VidarRankedElementFrame fused = MultiCameraFusion.fuseRankedElements(
+                new VidarVision[] {healthy, excluded}, filter, VidarConfig.FUSION_MAX_RANKED_ELEMENTS);
+        assertEquals(1, fused.count());
+        assertEquals(20.0, fused.at(0).robotX, 1e-9);
+    }
+
+    private static VidarVision cameraWith(VidarElementObservation observation) {
+        VidarElementObservation[] ranked = new VidarElementObservation[8];
+        ranked[0] = observation;
+        return new VidarVision(new VidarRankedElementFrame(ranked, 1, 0, 1, "cam", 8));
     }
 
     private static VidarElementObservation obs(
@@ -46,7 +91,7 @@ class MultiCameraFusionTest {
                 1L,
                 0, 0,
                 10, 10,
-                robotX, robotY, 5,
+                5, 5, 5,
                 areaPx, 1, 1, 1,
                 0.5,
                 VidarElementDetectorType.COLOR_BLOB,
@@ -54,7 +99,7 @@ class MultiCameraFusionTest {
                 range, 0.1,
                 range, range,
                 null,
-                0, range);
+                robotX, robotY);
     }
 
     private static VidarElementObservation obs(double confidence, double areaPx, double range) {

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/MultiCameraFusion.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/MultiCameraFusion.java
@@ -18,13 +18,21 @@ public final class MultiCameraFusion {
 
     private MultiCameraFusion() {}
 
+    /**
+     * Whether a camera slot should contribute to fusion this cycle.
+     * Shared by {@link #fuseRankedElements} and {@link VidarFusionEngine#update()}.
+     */
+    public static boolean isUsableCamera(VidarVision camera) {
+        return camera != null && !camera.isFailed() && !camera.isExcludedFromRotation();
+    }
+
     public static VidarRankedElementFrame fuseRankedElements(
             VidarVision[] cameras,
             VidarTemporalFilter temporalFilter,
             int fusionCap) {
         List<ScoredElement> candidates = new ArrayList<>();
         for (VidarVision camera : cameras) {
-            if (camera == null || camera.isFailed() || camera.isExcludedFromRotation()) {
+            if (!isUsableCamera(camera)) {
                 continue;
             }
             VidarRankedElementFrame frame = camera.getRankedElements();

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarFusionEngine.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/fusion/VidarFusionEngine.java
@@ -175,7 +175,7 @@ public final class VidarFusionEngine implements VidarVisionFusion {
 
         for (int i = 0; i < cameraCount; i++) {
             VidarVision camera = cameras[i];
-            if (camera == null || camera.isFailed() || camera.isExcludedFromRotation()) {
+            if (!MultiCameraFusion.isUsableCamera(camera)) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- Extract `MultiCameraFusion.isUsableCamera` and use it from `VidarFusionEngine.update()` so failed/excluded cameras share one skip seam.
- Add JVM tests that fail if fusion still ranks observations from failed or rotation-excluded cameras.
- Detach-equivalent `world.update(null)` coast/TTL remains covered by `WorldModelAssociationTest`; FusionEngine stays excluded from java-pure (OpenCV/frame types).

Closes #43
Related: #23

## Test plan
- [x] `cd java-pure && ./gradlew.bat test --tests MultiCameraFusionTest`
- [x] `python -m pytest tests/architecture/ -q`
- [ ] CI: ubuntu/windows test, java-compile, java-pure