### PR TITLE
Move VidarTagGate state onto VidarRuntime (#41)

### DIFF
--- a/docs/JAVA_PACKAGE_MAP.md
+++ b/docs/JAVA_PACKAGE_MAP.md
@@ -21,7 +21,7 @@
 | `vidar.api` | Student diagnostics | `VidarDiagnostics` |
 | `vidar.integration` | Optional pathing bridges (no hard deps) | `VidarPedroPose`, `VidarPedroPoseBridge`, `VidarPedroCorrectionTracker` |
 | `vidar.detect` | Contour / color-blob pipeline | `VidarContourProcessor`, `ElementDetector`, `PlateDetector` |
-| `vidar.tag` | AprilTag scout, crop decode, gates | `VidarAdaptiveTagProcessor`, `VidarTagDecodeWorker`, `TagDecodeBudget` |
+| `vidar.tag` | AprilTag scout, crop decode, gates | `VidarAdaptiveTagProcessor`, `VidarTagDecodeWorker`, `TagDecodeBudget`, `VidarTagGate` (facade), `VidarTagGateState` (owned by runtime) |
 | `vidar.fusion` | Localization, temporal filter, multi-camera fusion | `VidarFusionEngine`, `VidarLocalizationFusion`, `MultiCameraFusion`, `FieldPoseContext`, `VidarVisionFusion` |
 | `vidar.world` | Short-term track memory | `VidarWorldModel`, `VidarTrackAssociator` |
 | `vidar.frame` | Per-cycle immutable snapshots | `VidarObservationFrame`, `VidarSpatialSnapshot` |

--- a/docs/audits/priority-ledger.md
+++ b/docs/audits/priority-ledger.md
@@ -2,7 +2,7 @@
 
 Living ledger for orchestrator selection. GitHub issues are authoritative; this file is the in-repo snapshot.
 
-**Updated:** 2026-08-21 (after #60/#61; #43 in progress)  
+**Updated:** 2026-08-21 (after #62; #41 in progress)  
 **Identity:** `TA-C-GHill`  
 **Max active implementation PRs:** 1
 
@@ -18,14 +18,14 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 
 | Field | Value |
 |-------|--------|
-| Selected issue | [#43](https://github.com/The-Allsparks/ViDAR/issues/43) java-pure fusion/lifecycle seams |
-| Why highest priority | Unblocks god-method refactors; CI must catch failed-camera skip regressions |
-| Why ready | #38/#61 on main; WorldModel null-coast already covered |
-| Dependencies | #23 partial (TTL done) |
-| Expected deliverable | `MultiCameraFusion.isUsableCamera` + JVM skip tests; FusionEngine exclude stays |
+| Selected issue | [#41](https://github.com/The-Allsparks/ViDAR/issues/41) TagGate state on runtime |
+| Why highest priority | Process globals leak Auto→TeleOp / multi-create; blocks honest isolation tests |
+| Why ready | #43/#62 on main; Discover already calls facade after Spatial.create |
+| Dependencies | None hard |
+| Expected deliverable | `VidarTagGateState` owned by `VidarRuntime`; facade; java-pure + architecture guard |
 | Hardware required | No |
-| Branch | `test/java-pure-fusion-lifecycle-seams` |
-| Last delivered | [#33](https://github.com/The-Allsparks/ViDAR/issues/33) docs slice via [#61](https://github.com/The-Allsparks/ViDAR/pull/61) |
+| Branch | `refactor/taggate-runtime-owned-state` |
+| Last delivered | [#43](https://github.com/The-Allsparks/ViDAR/issues/43) via [#62](https://github.com/The-Allsparks/ViDAR/pull/62) |
 
 ## Ledger
 
@@ -34,20 +34,20 @@ Default order: safety blockers → correctness blockers → CI/build → multi-i
 | **#33 FTC packaging & lifecycle** | **P0 readiness** | **Active epic** | FORGE#4 | Open | — | Hardware for USB rows | Hub/#26/#27 next software |
 | #38 Package cycles | P1 | **Done** | #37 | **Closed** #60 | — | — | frame→detect removed |
 | #61 Install/lifecycle docs | P0 under #33 | **Done** | #33 | **Merged** | — | — | VERSION + close() guard |
+| #43 java-pure FusionEngine/Spatial | P2 | **Done** | #23 | **Closed** #62 | — | — | isUsableCamera seam |
+| #23 java-pure world/runtime tests | P2 | **Done** | #21 | **Closed** | — | — | TTL + #43 |
 | #37 Quality/CI epic | P1 | Active | This audit | Open | — | — | Children remain |
 | #25 Actions permissions + pins | P2 | **Done** | None | **Closed** #48 | — | — | SHA pins |
 | #44 Metrics percentiles | P1 | **Done** | #37 | **Closed** #59 | — | — | Discover Tick ms |
 | #40 Tick lock / mailbox / snapshots | P1 | Ready | #44, #27 | Open | — | Measure first | After #27 Hub/desktop |
-| #43 java-pure FusionEngine/Spatial | P2 | **Active** | #23 partial | Open | `test/java-pure-fusion-lifecycle-seams` | — | Land seam tests |
-| #41 TagGate static state | P2 | Ready | — | Open | — | — | After #43 |
-| #42 JSON single tuning surface | P2 | Ready | — | Open | — | — | After #43 / with #41 |
-| #39 God methods | P2 | Ready | — | Open | — | — | After #43 seams preferred |
+| #41 TagGate static state | P2 | **Active** | — | Open | `refactor/taggate-runtime-owned-state` | — | Land PR |
+| #42 JSON single tuning surface | P2 | Ready | — | Open | — | — | After #41 |
+| #39 God methods | P2 | Ready | — | Open | — | — | After #43 seams |
 | #45 Dedup default JSON | P3 | Ready | #42 | Open | — | — | Good first issue |
 | #46 Hide `runtime()` | P3 | Ready | — | Open | — | — | With #33 docs |
 | #47 Spotless baseline | P3 | Ready | — | Open | — | Format blast radius | Dedicated PR |
 | #19 Roadmap epic | P0 process | Active | — | Open | — | — | Keep checklist in sync |
 | #22 Sim range-fusion parity | P2 | Ready | #13 done | Open | — | Behind #33 for readiness claims | After #41/#42 |
-| #23 java-pure world/runtime tests | P2 | **Mostly done** | #21 done | Open | — | Remaining = #43 | Close after #43 |
 | #26 Hardware validation log | P1 under #33 | Blocked | Hardware | Open | — | No Control Hub | Do not invent results |
 | #27 Control Hub / desktop benches | P1 under #33 | Partial | Hardware for hub; #44 | Open | — | Hardware | Desktop OK; Hub blocked |
 | #16 Calibration visualization | P3 | Ready | #17 done | Open | — | Behind #33 | After packaging gate |

--- a/java-pure/build.gradle
+++ b/java-pure/build.gradle
@@ -81,6 +81,7 @@ sourceSets {
             exclude 'tag/VidarTagScoutRunner.java'
             exclude 'tag/VidarTagCropDecoder.java'
             exclude 'tag/VidarTagCropPlanner.java'
+            // Facade forwards to VidarRuntime; gate state itself (VidarTagGateState) is JVM-tested.
             exclude 'tag/VidarTagGate.java'
         }
     }

--- a/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/tag/VidarTagGateStateTest.java
+++ b/java-pure/src/test/java/org/firstinspires/ftc/teamcode/vidar/tag/VidarTagGateStateTest.java
@@ -1,0 +1,45 @@
+package org.firstinspires.ftc.teamcode.vidar.tag;
+
+import org.firstinspires.ftc.teamcode.vidar.frame.VidarFrameRegions;
+import org.firstinspires.ftc.teamcode.vidar.model.VidarTagScoutObservation;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VidarTagGateStateTest {
+
+    @Test
+    void sequentialInstancesDoNotLeakDriverRequest() {
+        VidarTagGateState first = new VidarTagGateState();
+        first.requestSample();
+        assertTrue(first.consumeDriverRequest());
+
+        VidarTagGateState second = new VidarTagGateState();
+        assertFalse(second.consumeDriverRequest(),
+                "new gate state must not inherit a prior driverRequested flag");
+    }
+
+    @Test
+    void resetClearsPendingDriverRequest() {
+        VidarTagGateState gate = new VidarTagGateState();
+        gate.requestSample();
+        gate.reset();
+        assertFalse(gate.consumeDriverRequest());
+    }
+
+    @Test
+    void shouldSampleHonorsDriverRequestOnce() {
+        VidarTagGateState gate = new VidarTagGateState();
+        gate.setAutoEnabled(false);
+        gate.requestSample();
+        VidarTagScoutObservation scout = scout(10);
+        assertTrue(gate.shouldSample(scout, 640));
+        assertFalse(gate.shouldSample(scout, 640));
+    }
+
+    private static VidarTagScoutObservation scout(double widthPx) {
+        return new VidarTagScoutObservation(
+                0, widthPx, 0.5, "cam", VidarFrameRegions.HorizontalBand.MIDDLE, 320, 240, 1L);
+    }
+}

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/runtime/VidarRuntime.java
@@ -20,6 +20,7 @@ import org.firstinspires.ftc.teamcode.vidar.schedule.VidarResourceBudget;
 import org.firstinspires.ftc.teamcode.vidar.tag.TagDecodeBudget;
 import org.firstinspires.ftc.teamcode.vidar.tag.VidarTagConfig;
 import org.firstinspires.ftc.teamcode.vidar.tag.VidarTagDecodeWorker;
+import org.firstinspires.ftc.teamcode.vidar.tag.VidarTagGateState;
 import org.firstinspires.ftc.teamcode.vidar.world.VidarWorldModel;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -42,6 +43,7 @@ public final class VidarRuntime {
     private final VidarWorldModel world;
     private final FieldPoseContext fieldPoseContext;
     private final TagDecodeBudget tagDecodeBudget;
+    private final VidarTagGateState tagGate = new VidarTagGateState();
     private final VidarTagDecodeWorker tagDecodeWorker;
     private final VidarResourceBudget resourceBudget;
     private final VidarObservationWorker observationWorker;
@@ -148,7 +150,13 @@ public final class VidarRuntime {
             fusionEngine = null;
         }
         fieldPoseContext.bindVision((VidarVisionFusion) null);
+        tagGate.reset();
         publishDetachedSnapshot();
+    }
+
+    /** Decode gate owned by this process runtime (driver request + pose cone). */
+    public VidarTagGateState tagGate() {
+        return tagGate;
     }
 
     public void resetMatchState() {
@@ -157,6 +165,7 @@ public final class VidarRuntime {
             fusionEngine.resetMatchState();
         }
         tagDecodeBudget.reset();
+        tagGate.reset();
     }
 
     public VidarSpatialSnapshot snapshot() {

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/tag/VidarTagGate.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/tag/VidarTagGate.java
@@ -1,84 +1,80 @@
 package org.firstinspires.ftc.teamcode.vidar.tag;
 
-import org.firstinspires.ftc.teamcode.vidar.VidarCoordinateFrames;
-import org.firstinspires.ftc.teamcode.vidar.model.VidarTagScoutObservation;
 import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
 import org.firstinspires.ftc.teamcode.vidar.config.VidarSeasonConfig;
+import org.firstinspires.ftc.teamcode.vidar.model.VidarTagScoutObservation;
+import org.firstinspires.ftc.teamcode.vidar.runtime.VidarRuntime;
 
 /**
- * When to run an AprilTag decode pass (driver trigger and/or pose cone).
+ * Student-facing static facade for AprilTag decode gating.
+ *
+ * <p>Mutable state lives on the live {@link VidarRuntime} ({@link VidarTagGateState}).
+ * Calls are no-ops / false when no runtime is active.
  */
 public final class VidarTagGate {
 
-    private static volatile boolean driverRequested;
-    private static volatile boolean autoEnabled = true;
-    private static volatile double expectedTagBearingDeg = Double.NaN;
-    private static volatile double cameraBearingDeg = 0;
-
     private VidarTagGate() {}
+
+    private static VidarTagGateState state() {
+        VidarRuntime runtime = VidarRuntime.getInstance();
+        return runtime == null ? null : runtime.tagGate();
+    }
 
     /** Call from gamepad edge (e.g. A button) to force one decode window. */
     public static void requestSample() {
-        driverRequested = true;
+        VidarTagGateState s = state();
+        if (s != null) {
+            s.requestSample();
+        }
     }
 
     public static void clearDriverRequest() {
-        driverRequested = false;
+        VidarTagGateState s = state();
+        if (s != null) {
+            s.clearDriverRequest();
+        }
     }
 
     public static boolean consumeDriverRequest() {
-        if (!driverRequested) {
-            return false;
-        }
-        driverRequested = false;
-        return true;
+        VidarTagGateState s = state();
+        return s != null && s.consumeDriverRequest();
     }
 
     public static void setAutoEnabled(boolean enabled) {
-        autoEnabled = enabled;
+        VidarTagGateState s = state();
+        if (s != null) {
+            s.setAutoEnabled(enabled);
+        }
     }
 
     /** Field bearing where the tag should appear (degrees). NaN disables pose gate. */
     public static void setExpectedTagBearingDeg(double bearingDeg) {
-        expectedTagBearingDeg = bearingDeg;
+        VidarTagGateState s = state();
+        if (s != null) {
+            s.setExpectedTagBearingDeg(bearingDeg);
+        }
     }
 
     /** Mount bearing of this camera on the robot (degrees). */
     public static void setCameraBearingDeg(double bearingDeg) {
-        cameraBearingDeg = bearingDeg;
+        VidarTagGateState s = state();
+        if (s != null) {
+            s.setCameraBearingDeg(bearingDeg);
+        }
     }
 
     /** Set pose-gate bearing from season tag map and a field pose prior. */
     public static void updateExpectedBearingFromFieldPose(
             Pose2D fieldPose,
             VidarSeasonConfig season) {
-        if (season == null || season.aprilTags.length == 0) {
-            return;
-        }
-        double bearing = season.nearestLocalizationTagFieldBearing(fieldPose);
-        if (!Double.isNaN(bearing)) {
-            setExpectedTagBearingDeg(bearing);
+        VidarTagGateState s = state();
+        if (s != null) {
+            s.updateExpectedBearingFromFieldPose(fieldPose, season);
         }
     }
 
     public static boolean shouldSample(VidarTagScoutObservation scout, int frameCols) {
-        if (!VidarTagConfig.ENABLED || scout == null) {
-            return false;
-        }
-        if (consumeDriverRequest()) {
-            return true;
-        }
-        if (!autoEnabled) {
-            return false;
-        }
-        if (Double.isNaN(expectedTagBearingDeg) || VidarTagConfig.POSE_GATE_DEG <= 0) {
-            return scout.apparentWidthPx >= VidarTagConfig.SCOUT_MIN_WIDTH_PX;
-        }
-        double centerErrPx = scout.cx - frameCols / 2.0;
-        double halfFovDeg = 35;
-        double bearingErr = centerErrPx / Math.max(1, frameCols) * halfFovDeg * 2;
-        double robotToTag = VidarCoordinateFrames.normalizeDeg(expectedTagBearingDeg - cameraBearingDeg);
-        return Math.abs(VidarCoordinateFrames.normalizeDeg(robotToTag - bearingErr)) <= VidarTagConfig.POSE_GATE_DEG;
+        VidarTagGateState s = state();
+        return s != null && s.shouldSample(scout, frameCols);
     }
-
 }

--- a/teamcode/org/firstinspires/ftc/teamcode/vidar/tag/VidarTagGateState.java
+++ b/teamcode/org/firstinspires/ftc/teamcode/vidar/tag/VidarTagGateState.java
@@ -1,0 +1,91 @@
+package org.firstinspires.ftc.teamcode.vidar.tag;
+
+import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
+import org.firstinspires.ftc.teamcode.vidar.VidarCoordinateFrames;
+import org.firstinspires.ftc.teamcode.vidar.config.VidarSeasonConfig;
+import org.firstinspires.ftc.teamcode.vidar.model.VidarTagScoutObservation;
+
+/**
+ * Instance-scoped AprilTag decode gate state (driver request + pose cone).
+ *
+ * <p>Owned by {@link org.firstinspires.ftc.teamcode.vidar.runtime.VidarRuntime} so Auto→TeleOp
+ * reuse and sequential create cannot leak {@code driverRequested} across logical lifetimes.
+ */
+public final class VidarTagGateState {
+
+    private volatile boolean driverRequested;
+    private volatile boolean autoEnabled = true;
+    private volatile double expectedTagBearingDeg = Double.NaN;
+    private volatile double cameraBearingDeg = 0;
+
+    /** Call from gamepad edge (e.g. A button) to force one decode window. */
+    public void requestSample() {
+        driverRequested = true;
+    }
+
+    public void clearDriverRequest() {
+        driverRequested = false;
+    }
+
+    public boolean consumeDriverRequest() {
+        if (!driverRequested) {
+            return false;
+        }
+        driverRequested = false;
+        return true;
+    }
+
+    public void setAutoEnabled(boolean enabled) {
+        autoEnabled = enabled;
+    }
+
+    /** Field bearing where the tag should appear (degrees). NaN disables pose gate. */
+    public void setExpectedTagBearingDeg(double bearingDeg) {
+        expectedTagBearingDeg = bearingDeg;
+    }
+
+    /** Mount bearing of this camera on the robot (degrees). */
+    public void setCameraBearingDeg(double bearingDeg) {
+        cameraBearingDeg = bearingDeg;
+    }
+
+    /** Set pose-gate bearing from season tag map and a field pose prior. */
+    public void updateExpectedBearingFromFieldPose(Pose2D fieldPose, VidarSeasonConfig season) {
+        if (season == null || season.aprilTags.length == 0) {
+            return;
+        }
+        double bearing = season.nearestLocalizationTagFieldBearing(fieldPose);
+        if (!Double.isNaN(bearing)) {
+            setExpectedTagBearingDeg(bearing);
+        }
+    }
+
+    public boolean shouldSample(VidarTagScoutObservation scout, int frameCols) {
+        if (!VidarTagConfig.ENABLED || scout == null) {
+            return false;
+        }
+        if (consumeDriverRequest()) {
+            return true;
+        }
+        if (!autoEnabled) {
+            return false;
+        }
+        if (Double.isNaN(expectedTagBearingDeg) || VidarTagConfig.POSE_GATE_DEG <= 0) {
+            return scout.apparentWidthPx >= VidarTagConfig.SCOUT_MIN_WIDTH_PX;
+        }
+        double centerErrPx = scout.cx - frameCols / 2.0;
+        double halfFovDeg = 35;
+        double bearingErr = centerErrPx / Math.max(1, frameCols) * halfFovDeg * 2;
+        double robotToTag = VidarCoordinateFrames.normalizeDeg(expectedTagBearingDeg - cameraBearingDeg);
+        return Math.abs(VidarCoordinateFrames.normalizeDeg(robotToTag - bearingErr))
+                <= VidarTagConfig.POSE_GATE_DEG;
+    }
+
+    /** Clear driver request and pose-gate knobs (attach/detach / match reset). */
+    public void reset() {
+        driverRequested = false;
+        autoEnabled = true;
+        expectedTagBearingDeg = Double.NaN;
+        cameraBearingDeg = 0;
+    }
+}

--- a/tests/architecture/test_hotpath_guards.py
+++ b/tests/architecture/test_hotpath_guards.py
@@ -107,3 +107,21 @@ def test_fusion_and_world_avoid_filesystem_io():
         "Filesystem I/O in detect/fusion/world/geometry can stall the Control Hub:\n"
         + "\n".join(hits)
     )
+
+
+STATIC_VOLATILE = re.compile(r"\bstatic\s+volatile\b")
+
+
+def test_tag_package_has_no_static_volatile_gate_state():
+    """Tag decode gate state must live on VidarRuntime (VidarTagGateState), not process globals."""
+    hits = []
+    for path in iter_vidar_java():
+        rel = path.relative_to(VIDAR_JAVA).as_posix()
+        if not rel.startswith("tag/"):
+            continue
+        if STATIC_VOLATILE.search(read_java(path)):
+            hits.append(rel)
+    assert not hits, (
+        "static volatile in tag/ leaks Auto→TeleOp / multi-camera gate state (#41):\n"
+        + "\n".join(hits)
+    )


### PR DESCRIPTION
## Summary
- Extract `VidarTagGateState` owned by `VidarRuntime`; reset on `detachVision` / `resetMatchState`.
- Keep `VidarTagGate.requestSample()` as a thin facade so Discover/TeleOp keep working.
- java-pure isolation tests + architecture guard against `static volatile` in `tag/`.

Closes #41

## Test plan
- [x] `./gradlew.bat test --tests org.firstinspires.ftc.teamcode.vidar.tag.*`
- [x] `python -m pytest tests/architecture/ -q`
- [ ] CI required checks green
- [ ] Manual: Discover A-button still requests a tag sample when cameras are up